### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Demonstration
 
-1. From the Command Pallete, type `netcdf-viewer.selectPythonEnv` to select your Python environment.
+1. From the Command Palette, type `netcdf-viewer.selectPythonEnv` to select your Python environment.
 2. Open a NetCDF file in the editor.
    - from the Welcome page, click on the "Open NetCDF File" button
    - or right-click a `.nc` file in the Explorer and select **Open in NetCDF Viewer**


### PR DESCRIPTION
## Summary
- fix small typo in README documentation

## Testing
- `npm test` *(fails: Unknown env config warning)*

------
https://chatgpt.com/codex/tasks/task_e_6842f18e47808325b5604617dda3cd2e