### PR TITLE
Add empty dataset test for tree provider

### DIFF
--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -155,5 +155,18 @@ test('NetCDFTreeProvider shows attributes for variables', async () => {
   assert.ok(tempAttrsNode, 'Attributes branch not found for data variable');
   const tempAttrChildren = await provider.getChildren(tempAttrsNode);
   const tempAttrLabels = tempAttrChildren.map((item: any) => item.label);
-  assert.deepStrictEqual(tempAttrLabels, ['units: "K"', 'long_name: "Temperature"']);
+assert.deepStrictEqual(tempAttrLabels, ['units: "K"', 'long_name: "Temperature"']);
+});
+
+test('NetCDFTreeProvider returns empty array when no dataset', async () => {
+  const { NetCDFTreeProvider } = await import('../extension');
+  const mockContext = {
+    workspaceState: {
+      get: () => undefined,
+    },
+  };
+
+  const provider = new NetCDFTreeProvider(mockContext as any);
+  const children = await provider.getChildren();
+  assert.deepStrictEqual(children, []);
 });


### PR DESCRIPTION
## Summary
- add test to ensure NetCDFTreeProvider returns empty children when no dataset is stored

## Testing
- `npm test` *(fails: Failed to parse response from update.code.visualstudio.com as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_6842f4f592dc8325a6cf870c5afb49b0