### PR TITLE
Add HTML dataset view

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
       {
         "command": "netcdf-viewer.openFile",
         "title": "Open NetCDF File…"
+      },
+      {
+        "command": "netcdf-viewer.showHtmlView",
+        "title": "Open NetCDF HTML View"
       }
     ],
     "views": {


### PR DESCRIPTION
## Summary
- register new `netcdf-viewer.showHtmlView` command
- display dataset in a collapsible HTML table

## Testing
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable?released=true as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb1d87a8832598520bd40bf94f05