### PR TITLE
Refactor: Add TypeScript interfaces and modular architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,34 @@
 # Contributing to NetCDF Viewer
 
-Thank you for your interest in contributing!  
+Thank you for your interest in contributing!
 This guide will help you set up your development environment and follow our coding standards.
+
+---
+
+## 📁 Project Structure
+
+```
+netcdf-viewer/
+├── src/
+│   ├── extension.ts      # Main extension entry point, commands, tree provider
+│   ├── types.ts          # TypeScript interfaces for NetCDF data structures
+│   └── test/
+│       └── extension.test.ts
+├── inspect_netcdf.py     # Python backend for reading NetCDF files
+├── media/
+│   └── chart.js          # Chart.js library for visualizations
+├── dist/                 # Webpack output (production bundle)
+├── out/                  # TypeScript output (for testing)
+└── .vscode-test.mjs      # Test runner configuration
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/extension.ts` | VS Code extension entry point, commands, tree view provider, webview generation |
+| `src/types.ts` | TypeScript interfaces (`NetCDFDataset`, `NetCDFVariable`, etc.) |
+| `inspect_netcdf.py` | Python script that uses xarray to extract NetCDF metadata and sample data |
 
 ---
 
@@ -51,11 +78,7 @@ This guide will help you set up your development environment and follow our codi
   npm test
   ```
 
-  or
-
-  ```sh
-  npx @vscode/test-cli --extensionDevelopmentPath=. --extensionTestsPath=./out/test/index.js
-  ```
+  This runs the full test pipeline: compile, lint, type check, then execute tests via `@vscode/test-cli`.
 
 ---
 
@@ -67,14 +90,35 @@ This guide will help you set up your development environment and follow our codi
   npm run lint
   ```
 
+- **Type check:**
+
+  ```sh
+  npm run tsc
+  ```
+
 - **Format your code:**
 
   ```sh
   npx prettier --write "src/**/*.{ts,js,json}"
   ```
 
-- **Pre-commit hooks:**  
+- **Pre-commit hooks:**
   We use [Husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/okonet/lint-staged) to automatically lint and format staged files before each commit.
+
+### TypeScript Guidelines
+
+- **Use proper types:** Import and use interfaces from `src/types.ts` rather than using `any`.
+- **Type guards:** Use type guard functions like `isInspectError()` for discriminated unions.
+- **New interfaces:** When adding new data structures, define interfaces in `src/types.ts` with JSDoc comments.
+
+```typescript
+// Good
+import { NetCDFDataset, StoredNetCDF } from './types';
+const stored = context.workspaceState.get<StoredNetCDF>('lastNetCDF');
+
+// Avoid
+const stored = context.workspaceState.get<any>('lastNetCDF');
+```
 
 ---
 
@@ -105,7 +149,8 @@ This guide will help you set up your development environment and follow our codi
 
 - Keep your changes focused and well-documented.
 - Write or update tests for new features or bug fixes.
-- If you’re unsure about anything, open an issue or draft PR for discussion!
+- Run `npm run tsc` to catch type errors before committing.
+- If you're unsure about anything, open an issue or draft PR for discussion!
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,25 +10,39 @@ This guide will help you set up your development environment and follow our codi
 ```
 netcdf-viewer/
 ├── src/
-│   ├── extension.ts      # Main extension entry point, commands, tree provider
-│   ├── types.ts          # TypeScript interfaces for NetCDF data structures
+│   ├── extension.ts              # Entry point: activate/deactivate, command registration
+│   ├── types.ts                  # TypeScript interfaces for NetCDF data structures
+│   ├── providers/
+│   │   └── NetCDFTreeProvider.ts # Tree view provider for NetCDF Explorer
+│   ├── views/
+│   │   ├── datasetHtmlView.ts    # HTML view for dataset structure
+│   │   └── variableWebview.ts    # Chart.js webview for variable preview
+│   ├── python/
+│   │   └── inspector.ts          # Python script execution and dependency checks
+│   ├── utils/
+│   │   └── sampleSlice.ts        # Shared utility functions
 │   └── test/
 │       └── extension.test.ts
-├── inspect_netcdf.py     # Python backend for reading NetCDF files
+├── inspect_netcdf.py             # Python backend for reading NetCDF files
 ├── media/
-│   └── chart.js          # Chart.js library for visualizations
-├── dist/                 # Webpack output (production bundle)
-├── out/                  # TypeScript output (for testing)
-└── .vscode-test.mjs      # Test runner configuration
+│   └── chart.js                  # Chart.js library for visualizations
+├── dist/                         # Webpack output (production bundle)
+├── out/                          # TypeScript output (for testing)
+└── .vscode-test.mjs              # Test runner configuration
 ```
 
 ### Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/extension.ts` | VS Code extension entry point, commands, tree view provider, webview generation |
+| `src/extension.ts` | Entry point with `activate`/`deactivate` and command registration |
 | `src/types.ts` | TypeScript interfaces (`NetCDFDataset`, `NetCDFVariable`, etc.) |
-| `inspect_netcdf.py` | Python script that uses xarray to extract NetCDF metadata and sample data |
+| `src/providers/NetCDFTreeProvider.ts` | Tree view data provider for the NetCDF Explorer sidebar |
+| `src/views/datasetHtmlView.ts` | Generates collapsible HTML view of dataset structure |
+| `src/views/variableWebview.ts` | Generates variable preview with Chart.js visualization |
+| `src/python/inspector.ts` | Executes Python script and checks dependencies |
+| `src/utils/sampleSlice.ts` | Shared `getSampleSlice()` utility function |
+| `inspect_netcdf.py` | Python script that uses xarray to extract NetCDF metadata |
 
 ---
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,14 @@
 import { execFile } from 'child_process';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import {
+  NetCDFDataset,
+  NetCDFVariable,
+  NamedVariable,
+  StoredNetCDF,
+  InspectResult,
+  isInspectError,
+} from './types';
 
 /**
  * Called when your extension is activated.
@@ -24,15 +32,17 @@ export function activate(context: vscode.ExtensionContext) {
       fileUri = picked;
     }
     try {
-      const xarrayDataset = await inspectNetCDFWithPython(context, fileUri.fsPath);
-      if (xarrayDataset.error) {
-        vscode.window.showErrorMessage('Python error: ' + xarrayDataset.error);
+      const result = await inspectNetCDFWithPython(context, fileUri.fsPath);
+      if (isInspectError(result)) {
+        vscode.window.showErrorMessage('Python error: ' + result.error);
         return;
       }
-      context.workspaceState.update('lastNetCDF', {
+      const xarrayDataset: NetCDFDataset = result;
+      const storedData: StoredNetCDF = {
         uri: fileUri,
         dataset: xarrayDataset,
-      });
+      };
+      context.workspaceState.update('lastNetCDF', storedData);
       provider.refresh();
       await vscode.commands.executeCommand('workbench.view.explorer');
       // Automatically open HTML view after loading
@@ -63,8 +73,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Register command to show dataset in an HTML view
   const showHtmlCmd = vscode.commands.registerCommand('netcdf-viewer.showHtmlView', () => {
-    const stored = context.workspaceState.get<any>('lastNetCDF');
-    if (!stored || !stored.dataset) {
+    const stored = context.workspaceState.get<StoredNetCDF>('lastNetCDF');
+    if (!stored?.dataset) {
       vscode.window.showWarningMessage('No NetCDF file loaded.');
       return;
     }
@@ -95,7 +105,7 @@ export function deactivate() {
 /**
  * Opens a Webview panel to preview the selected NetCDF variable.
  */
-function showVariableWebview(context: vscode.ExtensionContext, variable: any) {
+function showVariableWebview(context: vscode.ExtensionContext, variable: NamedVariable) {
   const panel = vscode.window.createWebviewPanel(
     'netcdfVarPreview',
     `Preview: ${variable.name || variable.label || '?'}`,
@@ -116,8 +126,8 @@ function showVariableWebview(context: vscode.ExtensionContext, variable: any) {
 }
 
 /** Opens a webview to display the entire dataset as an HTML table with collapsible sections. */
-function showDatasetHtmlView(context: vscode.ExtensionContext, dataset: any) {
-  const stored = context.workspaceState.get<any>('lastNetCDF');
+function showDatasetHtmlView(context: vscode.ExtensionContext, dataset: NetCDFDataset) {
+  const stored = context.workspaceState.get<StoredNetCDF>('lastNetCDF');
   const fileName = stored && stored.uri ? require('path').basename(stored.uri.fsPath) : 'NetCDF File';
   const panel = vscode.window.createWebviewPanel(
     'netcdfHtmlView',
@@ -129,7 +139,7 @@ function showDatasetHtmlView(context: vscode.ExtensionContext, dataset: any) {
 }
 
 /** Returns HTML markup for the dataset using nested <details> elements, ordered and labeled. */
-function getDatasetHtml(webview: vscode.Webview, dataset: any, fileName: string = 'NetCDF File'): string {
+function getDatasetHtml(webview: vscode.Webview, dataset: NetCDFDataset, fileName: string = 'NetCDF File'): string {
   const alwaysExpandable = new Set(['dtype', 'shape', 'dims', 'encoding']);
   function getSampleSlice(shape: number[] | undefined, sampleCount: number = 10): string {
     if (!shape || shape.length === 0) {
@@ -153,11 +163,12 @@ function getDatasetHtml(webview: vscode.Webview, dataset: any, fileName: string 
     return `[${slices.join(', ')}]`;
   }
 
-  function renderTree(node: any, label: string, indent = 0, parent?: any): string {
+  function renderTree(node: unknown, label: string, indent = 0, parent?: Record<string, any>): string {
     // Special handling for sample_data
     let displayLabel = label;
     if (label === 'sample_data' && Array.isArray(node) && parent && (parent.shape || parent.dims)) {
-      const shape = parent.shape || (parent.dims ? parent.dims.map((d: string) => parent[d]?.length || 0) : []);
+      const shape: number[] =
+        parent.shape || (parent.dims ? parent.dims.map((d: string) => parent[d]?.length || 0) : []);
       const sampleSlice = getSampleSlice(shape, node.length);
       displayLabel = `sample_data ${sampleSlice}`;
     }
@@ -239,7 +250,7 @@ function getDatasetHtml(webview: vscode.Webview, dataset: any, fileName: string 
 /**
  * Generates HTML for the Webview, including metadata and a mini-chart.
  */
-function getWebviewContent(webview: vscode.Webview, context: vscode.ExtensionContext, variable: any): string {
+function getWebviewContent(webview: vscode.Webview, context: vscode.ExtensionContext, variable: NamedVariable): string {
   // URI for local Chart.js script in media folder
   const chartJsUri = webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'media', 'chart.js'));
 
@@ -307,9 +318,9 @@ function getWebviewContent(webview: vscode.Webview, context: vscode.ExtensionCon
     <p><strong>Dimensions:</strong> ${
       variable.dims && variable.shape
         ? variable.dims.map((d: string, i: number) => `${d} (${variable.shape[i]})`).join(' × ')
-        : (variable.dimensions || variable.dims || []).join(' × ')
+        : (variable.dims || []).join(' × ')
     }</p>
-    <p><strong>Type:</strong> ${variable.type || variable.dtype || '?'}</p>
+    <p><strong>Type:</strong> ${variable.dtype || '?'}</p>
 
     <h2>Attributes</h2>
     <table>
@@ -368,6 +379,9 @@ ${
 </html>`;
 }
 
+/** Data attached to tree items - either the full dataset or a named variable */
+type TreeItemData = NetCDFDataset | NamedVariable | undefined;
+
 /**
  * Represents an item in the NetCDF Explorer view.
  */
@@ -375,7 +389,7 @@ class NetCDFTreeItem extends vscode.TreeItem {
   constructor(
     public readonly label: string,
     public readonly state: vscode.TreeItemCollapsibleState,
-    public readonly variable: any = undefined,
+    public readonly data: TreeItemData = undefined,
     public readonly contextValue: string = ''
   ) {
     super(label, state);
@@ -402,11 +416,11 @@ export class NetCDFTreeProvider implements vscode.TreeDataProvider<NetCDFTreeIte
   }
 
   async getChildren(element?: NetCDFTreeItem): Promise<NetCDFTreeItem[]> {
-    const stored = this.context.workspaceState.get<any>('lastNetCDF');
-    if (!stored || !stored.dataset) {
+    const stored = this.context.workspaceState.get<StoredNetCDF>('lastNetCDF');
+    if (!stored?.dataset) {
       return [];
     }
-    const ds = stored.dataset;
+    const ds: NetCDFDataset = stored.dataset;
     const fileName = stored.uri ? path.basename(stored.uri.fsPath) : 'NetCDF File';
     // If no element, show the file name as the root
     if (!element) {
@@ -429,63 +443,61 @@ export class NetCDFTreeProvider implements vscode.TreeDataProvider<NetCDFTreeIte
     }
 
     if (element.label === 'Coordinates') {
-      return Object.entries(ds.coords || {}).map(
-        ([coordName, v]) =>
-          new NetCDFTreeItem(
-            coordName,
-            vscode.TreeItemCollapsibleState.Collapsed,
-            {
-              ...(typeof v === 'object' && v !== null ? v : {}),
-              name: coordName,
-            },
-            'variable'
-          )
-      );
+      return Object.entries(ds.coords || {}).map(([coordName, v]) => {
+        const namedVar: NamedVariable = { ...v, name: coordName };
+        return new NetCDFTreeItem(
+          coordName,
+          vscode.TreeItemCollapsibleState.Collapsed,
+          namedVar,
+          'variable'
+        );
+      });
     }
 
     if (element.label === 'Data Variables') {
-      return Object.entries(ds.data_vars || {}).map(
-        ([varName, v]) =>
-          new NetCDFTreeItem(
-            varName,
-            vscode.TreeItemCollapsibleState.Collapsed,
-            {
-              ...(typeof v === 'object' && v !== null ? v : {}),
-              name: varName,
-            },
-            'variable'
-          )
-      );
+      return Object.entries(ds.data_vars || {}).map(([varName, v]) => {
+        const namedVar: NamedVariable = { ...v, name: varName };
+        return new NetCDFTreeItem(
+          varName,
+          vscode.TreeItemCollapsibleState.Collapsed,
+          namedVar,
+          'variable'
+        );
+      });
     }
 
     // If this is a variable, show its attributes, sample data, and encoding as children
-    if (element.contextValue === 'variable' && element.variable) {
+    if (element.contextValue === 'variable' && element.data) {
+      const varData = element.data as NamedVariable;
       return [
-        new NetCDFTreeItem('Attributes', vscode.TreeItemCollapsibleState.Collapsed, element.variable, 'attributes'),
-        new NetCDFTreeItem('Sample Data', vscode.TreeItemCollapsibleState.Collapsed, element.variable, 'sample'),
-        new NetCDFTreeItem('Encoding', vscode.TreeItemCollapsibleState.Collapsed, element.variable, 'encoding'),
+        new NetCDFTreeItem('Attributes', vscode.TreeItemCollapsibleState.Collapsed, varData, 'attributes'),
+        new NetCDFTreeItem('Sample Data', vscode.TreeItemCollapsibleState.Collapsed, varData, 'sample'),
+        new NetCDFTreeItem('Encoding', vscode.TreeItemCollapsibleState.Collapsed, varData, 'encoding'),
       ];
     }
 
     // Show encoding children
-    if (element.contextValue === 'encoding' && element.variable) {
-      return Object.entries(element.variable.encoding || {}).map(
+    if (element.contextValue === 'encoding' && element.data) {
+      const varData = element.data as NamedVariable;
+      return Object.entries(varData.encoding || {}).map(
         ([k, v]) => new NetCDFTreeItem(`${k}: ${JSON.stringify(v)}`, vscode.TreeItemCollapsibleState.None)
       );
     }
 
     // Show attribute children
-    if (element.contextValue === 'attributes' && element.variable) {
-      return Object.entries(element.variable.attrs || {}).map(
+    if (element.contextValue === 'attributes' && element.data) {
+      const varData = element.data as NamedVariable;
+      return Object.entries(varData.attrs || {}).map(
         ([k, v]) => new NetCDFTreeItem(`${k}: ${JSON.stringify(v)}`, vscode.TreeItemCollapsibleState.None)
       );
     }
 
     // Show sample data children
-    if (element.contextValue === 'sample' && element.variable) {
-      const sampleData = Array.isArray(element.variable.sample_data) ? element.variable.sample_data.slice(0, 10) : [];
+    if (element.contextValue === 'sample' && element.data) {
+      const varData = element.data as NamedVariable;
+      const sampleData = Array.isArray(varData.sample_data) ? varData.sample_data.slice(0, 10) : [];
       return sampleData.map(
-        (v: any, i: number) => new NetCDFTreeItem(`[${i}]: ${v}`, vscode.TreeItemCollapsibleState.None)
+        (v, i) => new NetCDFTreeItem(`[${i}]: ${v}`, vscode.TreeItemCollapsibleState.None)
       );
     }
 
@@ -496,7 +508,7 @@ export class NetCDFTreeProvider implements vscode.TreeDataProvider<NetCDFTreeIte
 /**
  * Inspects a NetCDF file using an external Python script and returns the parsed output.
  */
-async function inspectNetCDFWithPython(context: vscode.ExtensionContext, filePath: string): Promise<any> {
+async function inspectNetCDFWithPython(context: vscode.ExtensionContext, filePath: string): Promise<InspectResult> {
   const scriptPath = path.join(context.extensionPath, 'inspect_netcdf.py');
   const pythonPath = vscode.workspace.getConfiguration().get<string>('netcdfViewer.pythonPath', 'python');
   return new Promise((resolve, reject) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,25 +1,23 @@
-import { execFile } from 'child_process';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import {
-  NetCDFDataset,
-  NetCDFVariable,
-  NamedVariable,
-  StoredNetCDF,
-  InspectResult,
-  isInspectError,
-} from './types';
+import { NetCDFDataset, StoredNetCDF, isInspectError } from './types';
+import { inspectNetCDFWithPython, checkPythonDependencies } from './python/inspector';
+import { NetCDFTreeProvider } from './providers/NetCDFTreeProvider';
+import { showDatasetHtmlView } from './views/datasetHtmlView';
 
 /**
  * Called when your extension is activated.
  * @param context VS Code extension context
  */
-export function activate(context: vscode.ExtensionContext) {
-  // 1) Register "Open NetCDF File…", now accepting an optional URI
+export function activate(context: vscode.ExtensionContext): void {
+  // Register TreeDataProvider for NetCDF Explorer
+  const provider = new NetCDFTreeProvider(context);
+  vscode.window.registerTreeDataProvider('netcdfExplorer', provider);
+
+  // Register "Open NetCDF File…" command, accepting an optional URI
   const openCmd = vscode.commands.registerCommand('netcdf-viewer.openFile', async (uri?: vscode.Uri) => {
     let fileUri = uri;
 
-    // 2) If no URI was passed (user ran from Command Palette), prompt for one
+    // If no URI was passed (user ran from Command Palette), prompt for one
     if (!fileUri) {
       const [picked] =
         (await vscode.window.showOpenDialog({
@@ -31,6 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
       fileUri = picked;
     }
+
     try {
       const result = await inspectNetCDFWithPython(context, fileUri.fsPath);
       if (isInspectError(result)) {
@@ -53,7 +52,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(openCmd);
 
-  // Register a command to select Python environment using the Python extension
+  // Register command to select Python environment
   const selectPythonEnvCmd = vscode.commands.registerCommand('netcdf-viewer.selectPythonEnv', async () => {
     const picked = await vscode.window.showOpenDialog({
       canSelectMany: false,
@@ -82,11 +81,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(showHtmlCmd);
 
-  // 3) Register TreeDataProvider for NetCDF Explorer
-  const provider = new NetCDFTreeProvider(context);
-  vscode.window.registerTreeDataProvider('netcdfExplorer', provider);
-
-  // Check Python and dependencies
+  // Check Python and dependencies on startup
   const pythonPath = vscode.workspace.getConfiguration().get<string>('netcdfViewer.pythonPath', 'python');
   checkPythonDependencies(pythonPath).then((depError) => {
     if (depError) {
@@ -98,446 +93,6 @@ export function activate(context: vscode.ExtensionContext) {
 /**
  * Called when your extension is deactivated.
  */
-export function deactivate() {
+export function deactivate(): void {
   // No cleanup needed currently
-}
-
-/**
- * Opens a Webview panel to preview the selected NetCDF variable.
- */
-function showVariableWebview(context: vscode.ExtensionContext, variable: NamedVariable) {
-  const panel = vscode.window.createWebviewPanel(
-    'netcdfVarPreview',
-    `Preview: ${variable.name || variable.label || '?'}`,
-    vscode.ViewColumn.One,
-    {
-      enableScripts: true,
-      localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'media')],
-    }
-  );
-
-  panel.webview.html = getWebviewContent(panel.webview, context, variable);
-
-  panel.webview.onDidReceiveMessage((msg) => {
-    if (msg.command === 'alert') {
-      vscode.window.showInformationMessage(msg.text);
-    }
-  });
-}
-
-/** Opens a webview to display the entire dataset as an HTML table with collapsible sections. */
-function showDatasetHtmlView(context: vscode.ExtensionContext, dataset: NetCDFDataset) {
-  const stored = context.workspaceState.get<StoredNetCDF>('lastNetCDF');
-  const fileName = stored && stored.uri ? require('path').basename(stored.uri.fsPath) : 'NetCDF File';
-  const panel = vscode.window.createWebviewPanel(
-    'netcdfHtmlView',
-    fileName, // Use the filename as the tab heading
-    vscode.ViewColumn.One,
-    { enableScripts: true }
-  );
-  panel.webview.html = getDatasetHtml(panel.webview, dataset, fileName);
-}
-
-/** Returns HTML markup for the dataset using nested <details> elements, ordered and labeled. */
-function getDatasetHtml(webview: vscode.Webview, dataset: NetCDFDataset, fileName: string = 'NetCDF File'): string {
-  const alwaysExpandable = new Set(['dtype', 'shape', 'dims', 'encoding']);
-  function getSampleSlice(shape: number[] | undefined, sampleCount: number = 10): string {
-    if (!shape || shape.length === 0) {
-      return '';
-    }
-    let remaining = sampleCount;
-    const slices = [];
-    for (let i = 0; i < shape.length; ++i) {
-      if (remaining <= 0) {
-        slices.push('0:1');
-        continue;
-      }
-      let thisDim = 1;
-      for (let j = i + 1; j < shape.length; ++j) {
-        thisDim *= shape[j];
-      }
-      let count = Math.min(shape[i], Math.ceil(remaining / thisDim));
-      slices.push(`0:${count}`);
-      remaining = Math.floor(remaining / count);
-    }
-    return `[${slices.join(', ')}]`;
-  }
-
-  function renderTree(node: unknown, label: string, indent = 0, parent?: Record<string, any>): string {
-    // Special handling for sample_data
-    let displayLabel = label;
-    if (label === 'sample_data' && Array.isArray(node) && parent && (parent.shape || parent.dims)) {
-      const shape: number[] =
-        parent.shape || (parent.dims ? parent.dims.map((d: string) => parent[d]?.length || 0) : []);
-      const sampleSlice = getSampleSlice(shape, node.length);
-      displayLabel = `sample_data ${sampleSlice}`;
-    }
-
-    // Always expandable for certain keys, even if primitive
-    if (alwaysExpandable.has(label)) {
-      let content = '';
-      if (typeof node === 'object' && node !== null) {
-        content = Object.entries(node)
-          .map(([k, v]) => renderTree(v, k, indent + 1, node))
-          .join('');
-      } else {
-        content = `<div style="padding-left:${(indent + 1) * 20}px"><span class="val">${node}</span></div>`;
-      }
-      return `<details>
-        <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
-        ${content}
-      </details>`;
-    }
-
-    // For plain objects, render as expandable
-    if (typeof node === 'object' && node !== null && !Array.isArray(node)) {
-      const children = Object.entries(node)
-        .map(([k, v]) => renderTree(v, k, indent + 1, node))
-        .join('');
-      return `<details>
-      <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
-      ${children}
-    </details>`;
-    }
-
-    // For arrays, show a preview (first 10 values)
-    if (Array.isArray(node)) {
-      const preview = node
-        .slice(0, 10)
-        .map((v, i) => `<div style="padding-left:${(indent + 1) * 20}px">[${i}]: <span class="val">${v}</span></div>`)
-        .join('');
-      return `<details>
-      <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
-      ${preview}
-    </details>`;
-    }
-
-    // For primitives, just show as a line
-    return `<div style="padding-left:${indent * 20}px">${displayLabel}: <span class="val">${node}</span></div>`;
-  }
-
-  // Prepare ordered branches
-  const dims = dataset.dims ? renderTree(dataset.dims, 'Dimensions', 1) : '';
-  const coords = dataset.coords ? renderTree(dataset.coords, 'Coordinates', 1) : '';
-  const dataVars = dataset.data_vars ? renderTree(dataset.data_vars, 'Data Variables', 1) : '';
-  const globalAttrs = dataset.attrs ? renderTree(dataset.attrs, 'Global Attributes', 1) : '';
-
-  return `
-  <!DOCTYPE html>
-  <html>
-  <head>
-    <style>
-      body { font-family: sans-serif; padding: 16px; }
-      summary { font-weight: bold; cursor: pointer; }
-      details { margin-bottom: 8px; }
-      .val { color: #333; }
-    </style>
-  </head>
-  <body>
-    <h1>🔍 NetCDF Structure Viewer</h1>
-    <details>
-      <summary style="font-size:1.2em;">${fileName}</summary>
-      ${dims}
-      ${coords}
-      ${dataVars}
-      ${globalAttrs}
-    </details>
-  </body>
-  </html>
-  `;
-}
-
-/**
- * Generates HTML for the Webview, including metadata and a mini-chart.
- */
-function getWebviewContent(webview: vscode.Webview, context: vscode.ExtensionContext, variable: NamedVariable): string {
-  // URI for local Chart.js script in media folder
-  const chartJsUri = webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'media', 'chart.js'));
-
-  // Format variable summary like xarray
-  const dimsStr =
-    variable.dims && variable.dims.length > 0
-      ? `(${variable.dims
-          .map((d: string, i: number) => `${d}: ${variable.shape ? variable.shape[i] : '?'}`)
-          .join(', ')})`
-      : '';
-
-  const attrsStr = Object.entries(variable.attrs || {})
-    .map(([k, v]) => `<tr><td>${k}</td><td>${JSON.stringify(v)}</td></tr>`)
-    .join('');
-
-  // Read all data and take the first 10 values as sample
-  let rawData: any[] = [];
-  if (Array.isArray(variable.sample_data)) {
-    rawData = variable.sample_data;
-  }
-  const sampleData = rawData.slice(0, 10);
-
-  // Add the sample slice function
-  function getSampleSlice(shape: number[] | undefined, sampleCount: number = 10): string {
-    if (!shape || shape.length === 0) {
-      return '';
-    }
-    let remaining = sampleCount;
-    const slices = [];
-    for (let i = 0; i < shape.length; ++i) {
-      if (remaining <= 0) {
-        slices.push('0:1');
-        continue;
-      }
-      let thisDim = 1;
-      for (let j = i + 1; j < shape.length; ++j) {
-        thisDim *= shape[j];
-      }
-      let count = Math.min(shape[i], Math.ceil(remaining / thisDim));
-      slices.push(`0:${count}`);
-      remaining = Math.floor(remaining / count);
-    }
-    return `[${slices.join(', ')}]`;
-  }
-  const shape = variable.shape || (variable.dims ? variable.dims.map((d: string) => variable[d]?.length || 0) : []);
-  const sampleSlice = getSampleSlice(shape, sampleData.length);
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; img-src ${
-          webview.cspSource
-        } https:; script-src 'nonce-chart' ${webview.cspSource}; style-src ${webview.cspSource};">
-    <style>
-        body { font-family: sans-serif; padding: 16px; }
-        table { border-collapse: collapse; width: 100%; margin-bottom: 16px; }
-        th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; }
-    </style>
-    <title>Variable Preview</title>
-</head>
-<body>
-    <h1>${variable.name || variable.label || '?'}</h1>
-    <p><strong>Dimensions:</strong> ${
-      variable.dims && variable.shape
-        ? variable.dims.map((d: string, i: number) => `${d} (${variable.shape[i]})`).join(' × ')
-        : (variable.dims || []).join(' × ')
-    }</p>
-    <p><strong>Type:</strong> ${variable.dtype || '?'}</p>
-
-    <h2>Attributes</h2>
-    <table>
-        <tr><th>Key</th><th>Value</th></tr>
-        ${attrsStr || '<tr><td colspan="2"><em>No attributes</em></td></tr>'}
-    </table>
-
-    <h2>
-      Sample Data${sampleSlice ? ` ${sampleSlice}` : ''} (first ${sampleData.length} values)
-    </h2>
-${
-  sampleData.length > 0
-    ? `
-      <table>
-        <tr><th>Index</th><th>Value</th></tr>
-        ${sampleData.map((v, i) => `<tr><td>${i}</td><td>${v}</td></tr>`).join('')}
-      </table>
-      <canvas id="chart" width="400" height="200"></canvas>
-      `
-    : '<p><em>No data available for this variable.</em></p>'
-}
-    ${
-      sampleData.length > 0
-        ? `
-    <!-- Acquire VS Code API -->
-    <script nonce="nonce-chart">
-        const vscode = acquireVsCodeApi();
-    </script>
-    <!-- Chart.js library -->
-    <script nonce="nonce-chart" src="${chartJsUri}"></script>
-    <!-- Render the chart -->
-    <script nonce="nonce-chart">
-        const ctx = document.getElementById('chart').getContext('2d');
-        new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: ${JSON.stringify(sampleData.map((_, i) => i))},
-                datasets: [{
-                    label: '${variable.name || variable.label || '?'}',
-                    data: ${JSON.stringify(sampleData)},
-                    fill: false,
-                    tension: 0.1
-                }]
-            },
-            options: { responsive: true }
-        });
-
-        ctx.canvas.addEventListener('click', () => {
-            vscode.postMessage({ command: 'alert', text: 'Chart clicked!' });
-        });
-    </script>
-    `
-        : ''
-    }
-</body>
-</html>`;
-}
-
-/** Data attached to tree items - either the full dataset or a named variable */
-type TreeItemData = NetCDFDataset | NamedVariable | undefined;
-
-/**
- * Represents an item in the NetCDF Explorer view.
- */
-class NetCDFTreeItem extends vscode.TreeItem {
-  constructor(
-    public readonly label: string,
-    public readonly state: vscode.TreeItemCollapsibleState,
-    public readonly data: TreeItemData = undefined,
-    public readonly contextValue: string = ''
-  ) {
-    super(label, state);
-    this.contextValue = contextValue;
-  }
-}
-
-/**
- * Provides data (variables) for the NetCDF Explorer tree view.
- */
-export class NetCDFTreeProvider implements vscode.TreeDataProvider<NetCDFTreeItem> {
-  private _onDidChange = new vscode.EventEmitter<NetCDFTreeItem | undefined>();
-  readonly onDidChangeTreeData = this._onDidChange.event;
-
-  constructor(private context: vscode.ExtensionContext) {}
-
-  /** Refresh the entire tree */
-  refresh(): void {
-    this._onDidChange.fire(undefined);
-  }
-
-  getTreeItem(item: NetCDFTreeItem): vscode.TreeItem {
-    return item;
-  }
-
-  async getChildren(element?: NetCDFTreeItem): Promise<NetCDFTreeItem[]> {
-    const stored = this.context.workspaceState.get<StoredNetCDF>('lastNetCDF');
-    if (!stored?.dataset) {
-      return [];
-    }
-    const ds: NetCDFDataset = stored.dataset;
-    const fileName = stored.uri ? path.basename(stored.uri.fsPath) : 'NetCDF File';
-    // If no element, show the file name as the root
-    if (!element) {
-      return [new NetCDFTreeItem(fileName, vscode.TreeItemCollapsibleState.Expanded, ds, 'file')];
-    }
-
-    // If the element is the file node, show the main branches
-    if (element.contextValue === 'file') {
-      return [
-        new NetCDFTreeItem('Dimensions', vscode.TreeItemCollapsibleState.Collapsed),
-        new NetCDFTreeItem('Coordinates', vscode.TreeItemCollapsibleState.Collapsed),
-        new NetCDFTreeItem('Data Variables', vscode.TreeItemCollapsibleState.Collapsed),
-      ];
-    }
-
-    if (element.label === 'Dimensions') {
-      return Object.entries(ds.dims || {}).map(
-        ([dim, size]) => new NetCDFTreeItem(`${dim} (${size})`, vscode.TreeItemCollapsibleState.None)
-      );
-    }
-
-    if (element.label === 'Coordinates') {
-      return Object.entries(ds.coords || {}).map(([coordName, v]) => {
-        const namedVar: NamedVariable = { ...v, name: coordName };
-        return new NetCDFTreeItem(
-          coordName,
-          vscode.TreeItemCollapsibleState.Collapsed,
-          namedVar,
-          'variable'
-        );
-      });
-    }
-
-    if (element.label === 'Data Variables') {
-      return Object.entries(ds.data_vars || {}).map(([varName, v]) => {
-        const namedVar: NamedVariable = { ...v, name: varName };
-        return new NetCDFTreeItem(
-          varName,
-          vscode.TreeItemCollapsibleState.Collapsed,
-          namedVar,
-          'variable'
-        );
-      });
-    }
-
-    // If this is a variable, show its attributes, sample data, and encoding as children
-    if (element.contextValue === 'variable' && element.data) {
-      const varData = element.data as NamedVariable;
-      return [
-        new NetCDFTreeItem('Attributes', vscode.TreeItemCollapsibleState.Collapsed, varData, 'attributes'),
-        new NetCDFTreeItem('Sample Data', vscode.TreeItemCollapsibleState.Collapsed, varData, 'sample'),
-        new NetCDFTreeItem('Encoding', vscode.TreeItemCollapsibleState.Collapsed, varData, 'encoding'),
-      ];
-    }
-
-    // Show encoding children
-    if (element.contextValue === 'encoding' && element.data) {
-      const varData = element.data as NamedVariable;
-      return Object.entries(varData.encoding || {}).map(
-        ([k, v]) => new NetCDFTreeItem(`${k}: ${JSON.stringify(v)}`, vscode.TreeItemCollapsibleState.None)
-      );
-    }
-
-    // Show attribute children
-    if (element.contextValue === 'attributes' && element.data) {
-      const varData = element.data as NamedVariable;
-      return Object.entries(varData.attrs || {}).map(
-        ([k, v]) => new NetCDFTreeItem(`${k}: ${JSON.stringify(v)}`, vscode.TreeItemCollapsibleState.None)
-      );
-    }
-
-    // Show sample data children
-    if (element.contextValue === 'sample' && element.data) {
-      const varData = element.data as NamedVariable;
-      const sampleData = Array.isArray(varData.sample_data) ? varData.sample_data.slice(0, 10) : [];
-      return sampleData.map(
-        (v, i) => new NetCDFTreeItem(`[${i}]: ${v}`, vscode.TreeItemCollapsibleState.None)
-      );
-    }
-
-    return [];
-  }
-}
-
-/**
- * Inspects a NetCDF file using an external Python script and returns the parsed output.
- */
-async function inspectNetCDFWithPython(context: vscode.ExtensionContext, filePath: string): Promise<InspectResult> {
-  const scriptPath = path.join(context.extensionPath, 'inspect_netcdf.py');
-  const pythonPath = vscode.workspace.getConfiguration().get<string>('netcdfViewer.pythonPath', 'python');
-  return new Promise((resolve, reject) => {
-    execFile(pythonPath, [scriptPath, filePath], { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
-      if (err) {
-        // Show stderr in the error message for debugging
-        reject(`Python error: ${stderr || err.message}`);
-      } else {
-        try {
-          resolve(JSON.parse(stdout));
-        } catch (e) {
-          reject('Failed to parse Python output: ' + stdout);
-        }
-      }
-    });
-  });
-}
-
-/**
- * Checks Python and required dependencies, returning an error message if any are missing.
- */
-async function checkPythonDependencies(pythonPath: string): Promise<string | null> {
-  return new Promise((resolve) => {
-    execFile(pythonPath, ['-c', 'import xarray; import netCDF4'], (err) => {
-      if (err) {
-        resolve('Python, xarray, or netCDF4 not found. Please check your Python path and environment.');
-      } else {
-        resolve(null);
-      }
-    });
-  });
 }

--- a/src/providers/NetCDFTreeProvider.ts
+++ b/src/providers/NetCDFTreeProvider.ts
@@ -1,0 +1,118 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { NetCDFDataset, NamedVariable, StoredNetCDF } from '../types';
+
+/** Data attached to tree items - either the full dataset or a named variable */
+export type TreeItemData = NetCDFDataset | NamedVariable | undefined;
+
+/**
+ * Represents an item in the NetCDF Explorer tree view.
+ */
+export class NetCDFTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly label: string,
+    public readonly state: vscode.TreeItemCollapsibleState,
+    public readonly data: TreeItemData = undefined,
+    public readonly contextValue: string = ''
+  ) {
+    super(label, state);
+    this.contextValue = contextValue;
+  }
+}
+
+/**
+ * Provides data (variables) for the NetCDF Explorer tree view.
+ */
+export class NetCDFTreeProvider implements vscode.TreeDataProvider<NetCDFTreeItem> {
+  private _onDidChange = new vscode.EventEmitter<NetCDFTreeItem | undefined>();
+  readonly onDidChangeTreeData = this._onDidChange.event;
+
+  constructor(private context: vscode.ExtensionContext) {}
+
+  /** Refresh the entire tree */
+  refresh(): void {
+    this._onDidChange.fire(undefined);
+  }
+
+  getTreeItem(item: NetCDFTreeItem): vscode.TreeItem {
+    return item;
+  }
+
+  async getChildren(element?: NetCDFTreeItem): Promise<NetCDFTreeItem[]> {
+    const stored = this.context.workspaceState.get<StoredNetCDF>('lastNetCDF');
+    if (!stored?.dataset) {
+      return [];
+    }
+    const ds: NetCDFDataset = stored.dataset;
+    const fileName = stored.uri ? path.basename(stored.uri.fsPath) : 'NetCDF File';
+
+    // If no element, show the file name as the root
+    if (!element) {
+      return [new NetCDFTreeItem(fileName, vscode.TreeItemCollapsibleState.Expanded, ds, 'file')];
+    }
+
+    // If the element is the file node, show the main branches
+    if (element.contextValue === 'file') {
+      return [
+        new NetCDFTreeItem('Dimensions', vscode.TreeItemCollapsibleState.Collapsed),
+        new NetCDFTreeItem('Coordinates', vscode.TreeItemCollapsibleState.Collapsed),
+        new NetCDFTreeItem('Data Variables', vscode.TreeItemCollapsibleState.Collapsed),
+      ];
+    }
+
+    if (element.label === 'Dimensions') {
+      return Object.entries(ds.dims || {}).map(
+        ([dim, size]) => new NetCDFTreeItem(`${dim} (${size})`, vscode.TreeItemCollapsibleState.None)
+      );
+    }
+
+    if (element.label === 'Coordinates') {
+      return Object.entries(ds.coords || {}).map(([coordName, v]) => {
+        const namedVar: NamedVariable = { ...v, name: coordName };
+        return new NetCDFTreeItem(coordName, vscode.TreeItemCollapsibleState.Collapsed, namedVar, 'variable');
+      });
+    }
+
+    if (element.label === 'Data Variables') {
+      return Object.entries(ds.data_vars || {}).map(([varName, v]) => {
+        const namedVar: NamedVariable = { ...v, name: varName };
+        return new NetCDFTreeItem(varName, vscode.TreeItemCollapsibleState.Collapsed, namedVar, 'variable');
+      });
+    }
+
+    // If this is a variable, show its attributes, sample data, and encoding as children
+    if (element.contextValue === 'variable' && element.data) {
+      const varData = element.data as NamedVariable;
+      return [
+        new NetCDFTreeItem('Attributes', vscode.TreeItemCollapsibleState.Collapsed, varData, 'attributes'),
+        new NetCDFTreeItem('Sample Data', vscode.TreeItemCollapsibleState.Collapsed, varData, 'sample'),
+        new NetCDFTreeItem('Encoding', vscode.TreeItemCollapsibleState.Collapsed, varData, 'encoding'),
+      ];
+    }
+
+    // Show encoding children
+    if (element.contextValue === 'encoding' && element.data) {
+      const varData = element.data as NamedVariable;
+      return Object.entries(varData.encoding || {}).map(
+        ([k, v]) => new NetCDFTreeItem(`${k}: ${JSON.stringify(v)}`, vscode.TreeItemCollapsibleState.None)
+      );
+    }
+
+    // Show attribute children
+    if (element.contextValue === 'attributes' && element.data) {
+      const varData = element.data as NamedVariable;
+      return Object.entries(varData.attrs || {}).map(
+        ([k, v]) => new NetCDFTreeItem(`${k}: ${JSON.stringify(v)}`, vscode.TreeItemCollapsibleState.None)
+      );
+    }
+
+    // Show sample data children
+    if (element.contextValue === 'sample' && element.data) {
+      const varData = element.data as NamedVariable;
+      const sampleData = Array.isArray(varData.sample_data) ? varData.sample_data.slice(0, 10) : [];
+      return sampleData.map((v, i) => new NetCDFTreeItem(`[${i}]: ${v}`, vscode.TreeItemCollapsibleState.None));
+    }
+
+    return [];
+  }
+}

--- a/src/python/inspector.ts
+++ b/src/python/inspector.ts
@@ -1,0 +1,52 @@
+import { execFile } from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { InspectResult } from '../types';
+
+/**
+ * Inspects a NetCDF file using an external Python script and returns the parsed output.
+ *
+ * @param context - VS Code extension context (for locating the Python script)
+ * @param filePath - Path to the NetCDF file to inspect
+ * @returns Parsed dataset or error object
+ */
+export async function inspectNetCDFWithPython(
+  context: vscode.ExtensionContext,
+  filePath: string
+): Promise<InspectResult> {
+  const scriptPath = path.join(context.extensionPath, 'inspect_netcdf.py');
+  const pythonPath = vscode.workspace.getConfiguration().get<string>('netcdfViewer.pythonPath', 'python');
+
+  return new Promise((resolve, reject) => {
+    execFile(pythonPath, [scriptPath, filePath], { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (err) {
+        // Show stderr in the error message for debugging
+        reject(`Python error: ${stderr || err.message}`);
+      } else {
+        try {
+          resolve(JSON.parse(stdout));
+        } catch (e) {
+          reject('Failed to parse Python output: ' + stdout);
+        }
+      }
+    });
+  });
+}
+
+/**
+ * Checks Python and required dependencies, returning an error message if any are missing.
+ *
+ * @param pythonPath - Path to Python executable
+ * @returns Error message if dependencies are missing, null otherwise
+ */
+export async function checkPythonDependencies(pythonPath: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(pythonPath, ['-c', 'import xarray; import netCDF4'], (err) => {
+      if (err) {
+        resolve('Python, xarray, or netCDF4 not found. Please check your Python path and environment.');
+      } else {
+        resolve(null);
+      }
+    });
+  });
+}

--- a/src/python/inspector.ts
+++ b/src/python/inspector.ts
@@ -17,16 +17,27 @@ export async function inspectNetCDFWithPython(
   const scriptPath = path.join(context.extensionPath, 'inspect_netcdf.py');
   const pythonPath = vscode.workspace.getConfiguration().get<string>('netcdfViewer.pythonPath', 'python');
 
+  const MAX_ERROR_LENGTH = 500;
+
   return new Promise((resolve, reject) => {
     execFile(pythonPath, [scriptPath, filePath], { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
       if (err) {
-        // Show stderr in the error message for debugging
-        reject(`Python error: ${stderr || err.message}`);
+        // Truncate error output to avoid overwhelming the user
+        let details = stderr || err.message || 'Unknown error';
+        if (details.length > MAX_ERROR_LENGTH) {
+          details = details.slice(0, MAX_ERROR_LENGTH) + '... [truncated]';
+        }
+        reject(`Python error: ${details}`);
       } else {
         try {
           resolve(JSON.parse(stdout));
         } catch (e) {
-          reject('Failed to parse Python output: ' + stdout);
+          // Truncate output snippet for parse errors
+          let snippet = stdout || '';
+          if (snippet.length > MAX_ERROR_LENGTH) {
+            snippet = snippet.slice(0, MAX_ERROR_LENGTH) + '... [truncated]';
+          }
+          reject(`Failed to parse Python output: ${snippet}`);
         }
       }
     });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -85,9 +85,12 @@ test('NetCDFTreeProvider shows attributes for variables', async () => {
       get: () => ({
         uri: { fsPath: '/path/to/test.nc' },
         dataset: {
-          dims: {},
+          dims: { time: 3, lat: 10, lon: 20 },
           coords: {
             time: {
+              dims: ['time'],
+              shape: [3],
+              dtype: 'datetime64[ns]',
               attrs: { standard_name: 'time', axis: 'T' },
               sample_data: [0, 1, 2],
               encoding: {},
@@ -95,6 +98,9 @@ test('NetCDFTreeProvider shows attributes for variables', async () => {
           },
           data_vars: {
             temp: {
+              dims: ['time', 'lat', 'lon'],
+              shape: [3, 10, 20],
+              dtype: 'float32',
               attrs: { units: 'K', long_name: 'Temperature' },
               sample_data: [273.15, 274.15],
               encoding: {},

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -36,7 +36,7 @@ test('NetCDF Explorer provider should be registered', () => {
 });
 
 test('NetCDFTreeProvider returns root nodes', async () => {
-  const { NetCDFTreeProvider } = await import('../extension');
+  const { NetCDFTreeProvider } = await import('../providers/NetCDFTreeProvider');
   const mockContext = {
     workspaceState: {
       get: () => ({
@@ -55,7 +55,7 @@ test('NetCDFTreeProvider returns root nodes', async () => {
 });
 
 test('NetCDFTreeProvider returns dimension children', async () => {
-  const { NetCDFTreeProvider } = await import('../extension');
+  const { NetCDFTreeProvider } = await import('../providers/NetCDFTreeProvider');
   const mockContext = {
     workspaceState: {
       get: () => ({
@@ -79,7 +79,7 @@ test('NetCDFTreeProvider returns dimension children', async () => {
 });
 
 test('NetCDFTreeProvider shows attributes for variables', async () => {
-  const { NetCDFTreeProvider } = await import('../extension');
+  const { NetCDFTreeProvider } = await import('../providers/NetCDFTreeProvider');
   const mockContext = {
     workspaceState: {
       get: () => ({
@@ -134,7 +134,7 @@ assert.deepStrictEqual(tempAttrLabels, ['units: "K"', 'long_name: "Temperature"'
 });
 
 test('NetCDFTreeProvider returns empty array when no dataset', async () => {
-  const { NetCDFTreeProvider } = await import('../extension');
+  const { NetCDFTreeProvider } = await import('../providers/NetCDFTreeProvider');
   const mockContext = {
     workspaceState: {
       get: () => undefined,
@@ -147,7 +147,7 @@ test('NetCDFTreeProvider returns empty array when no dataset', async () => {
 });
 
 test('NetCDFTreeProvider shows file name as root', async () => {
-  const { NetCDFTreeProvider } = await import('../extension');
+  const { NetCDFTreeProvider } = await import('../providers/NetCDFTreeProvider');
   const mockContext = {
     workspaceState: {
       get: () => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,71 @@
+/**
+ * TypeScript interfaces for NetCDF dataset structures.
+ * These mirror the JSON output from inspect_netcdf.py
+ */
+
+/**
+ * Represents a single variable (coordinate or data variable) in a NetCDF dataset.
+ */
+export interface NetCDFVariable {
+  /** Dimension names for this variable */
+  dims: string[];
+  /** Shape of the array (size of each dimension) */
+  shape: number[];
+  /** Data type (e.g., 'float32', 'int64', 'datetime64[ns]') */
+  dtype: string;
+  /** Variable attributes (units, long_name, etc.) */
+  attrs: Record<string, unknown>;
+  /** First N sample values from the variable */
+  sample_data: (number | string | null)[];
+  /** Encoding information (compression, fill value, etc.) */
+  encoding: Record<string, unknown>;
+}
+
+/**
+ * Represents a complete NetCDF dataset as returned by inspect_netcdf.py
+ */
+export interface NetCDFDataset {
+  /** Dimension names mapped to their sizes */
+  dims: Record<string, number>;
+  /** Coordinate variables */
+  coords: Record<string, NetCDFVariable>;
+  /** Data variables */
+  data_vars: Record<string, NetCDFVariable>;
+  /** Global attributes */
+  attrs?: Record<string, unknown>;
+}
+
+/**
+ * Response from the Python inspection script.
+ * Either contains a valid dataset or an error message.
+ */
+export type InspectResult =
+  | NetCDFDataset
+  | { error: string };
+
+/**
+ * Helper type guard to check if the result is an error
+ */
+export function isInspectError(result: InspectResult): result is { error: string } {
+  return 'error' in result && typeof result.error === 'string';
+}
+
+/**
+ * Stored state for a loaded NetCDF file
+ */
+export interface StoredNetCDF {
+  /** URI of the opened file */
+  uri: { fsPath: string };
+  /** Parsed dataset */
+  dataset: NetCDFDataset;
+}
+
+/**
+ * Variable with name attached (used when passing to webviews)
+ */
+export interface NamedVariable extends NetCDFVariable {
+  /** Variable name */
+  name: string;
+  /** Optional label for display */
+  label?: string;
+}

--- a/src/utils/escapeHtml.ts
+++ b/src/utils/escapeHtml.ts
@@ -1,0 +1,15 @@
+/**
+ * Escapes HTML special characters to prevent XSS attacks.
+ *
+ * @param unsafe - String that may contain HTML special characters
+ * @returns Escaped string safe for HTML insertion
+ */
+export function escapeHtml(unsafe: unknown): string {
+  const str = String(unsafe ?? '');
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/src/utils/sampleSlice.ts
+++ b/src/utils/sampleSlice.ts
@@ -1,0 +1,29 @@
+/**
+ * Computes a slice notation string for displaying sample data indices.
+ * For example, a shape of [10, 20, 30] with 10 samples might return "[0:2, 0:5, 0:1]"
+ *
+ * @param shape - Array dimensions
+ * @param sampleCount - Number of sample values (default 10)
+ * @returns Slice notation string like "[0:2, 0:5]" or empty string if no shape
+ */
+export function getSampleSlice(shape: number[] | undefined, sampleCount: number = 10): string {
+  if (!shape || shape.length === 0) {
+    return '';
+  }
+  let remaining = sampleCount;
+  const slices: string[] = [];
+  for (let i = 0; i < shape.length; ++i) {
+    if (remaining <= 0) {
+      slices.push('0:1');
+      continue;
+    }
+    let thisDim = 1;
+    for (let j = i + 1; j < shape.length; ++j) {
+      thisDim *= shape[j];
+    }
+    const count = Math.min(shape[i], Math.ceil(remaining / thisDim));
+    slices.push(`0:${count}`);
+    remaining = Math.floor(remaining / count);
+  }
+  return `[${slices.join(', ')}]`;
+}

--- a/src/views/datasetHtmlView.ts
+++ b/src/views/datasetHtmlView.ts
@@ -1,0 +1,118 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { NetCDFDataset, StoredNetCDF } from '../types';
+import { getSampleSlice } from '../utils/sampleSlice';
+
+/**
+ * Opens a webview to display the entire dataset as an HTML table with collapsible sections.
+ *
+ * @param context - VS Code extension context
+ * @param dataset - The NetCDF dataset to display
+ */
+export function showDatasetHtmlView(context: vscode.ExtensionContext, dataset: NetCDFDataset): void {
+  const stored = context.workspaceState.get<StoredNetCDF>('lastNetCDF');
+  const fileName = stored?.uri ? path.basename(stored.uri.fsPath) : 'NetCDF File';
+
+  const panel = vscode.window.createWebviewPanel(
+    'netcdfHtmlView',
+    fileName, // Use the filename as the tab heading
+    vscode.ViewColumn.One,
+    { enableScripts: true }
+  );
+
+  panel.webview.html = getDatasetHtml(dataset, fileName);
+}
+
+/**
+ * Returns HTML markup for the dataset using nested <details> elements, ordered and labeled.
+ *
+ * @param dataset - The NetCDF dataset
+ * @param fileName - Name of the file for display
+ * @returns HTML string
+ */
+export function getDatasetHtml(dataset: NetCDFDataset, fileName: string = 'NetCDF File'): string {
+  const alwaysExpandable = new Set(['dtype', 'shape', 'dims', 'encoding']);
+
+  function renderTree(node: unknown, label: string, indent = 0, parent?: Record<string, any>): string {
+    // Special handling for sample_data
+    let displayLabel = label;
+    if (label === 'sample_data' && Array.isArray(node) && parent && (parent.shape || parent.dims)) {
+      const shape: number[] =
+        parent.shape || (parent.dims ? parent.dims.map((d: string) => parent[d]?.length || 0) : []);
+      const sampleSlice = getSampleSlice(shape, node.length);
+      displayLabel = `sample_data ${sampleSlice}`;
+    }
+
+    // Always expandable for certain keys, even if primitive
+    if (alwaysExpandable.has(label)) {
+      let content = '';
+      if (typeof node === 'object' && node !== null) {
+        content = Object.entries(node)
+          .map(([k, v]) => renderTree(v, k, indent + 1, node))
+          .join('');
+      } else {
+        content = `<div style="padding-left:${(indent + 1) * 20}px"><span class="val">${node}</span></div>`;
+      }
+      return `<details>
+        <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
+        ${content}
+      </details>`;
+    }
+
+    // For plain objects, render as expandable
+    if (typeof node === 'object' && node !== null && !Array.isArray(node)) {
+      const children = Object.entries(node)
+        .map(([k, v]) => renderTree(v, k, indent + 1, node))
+        .join('');
+      return `<details>
+      <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
+      ${children}
+    </details>`;
+    }
+
+    // For arrays, show a preview (first 10 values)
+    if (Array.isArray(node)) {
+      const preview = node
+        .slice(0, 10)
+        .map((v, i) => `<div style="padding-left:${(indent + 1) * 20}px">[${i}]: <span class="val">${v}</span></div>`)
+        .join('');
+      return `<details>
+      <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
+      ${preview}
+    </details>`;
+    }
+
+    // For primitives, just show as a line
+    return `<div style="padding-left:${indent * 20}px">${displayLabel}: <span class="val">${node}</span></div>`;
+  }
+
+  // Prepare ordered branches
+  const dims = dataset.dims ? renderTree(dataset.dims, 'Dimensions', 1) : '';
+  const coords = dataset.coords ? renderTree(dataset.coords, 'Coordinates', 1) : '';
+  const dataVars = dataset.data_vars ? renderTree(dataset.data_vars, 'Data Variables', 1) : '';
+  const globalAttrs = dataset.attrs ? renderTree(dataset.attrs, 'Global Attributes', 1) : '';
+
+  return `
+  <!DOCTYPE html>
+  <html>
+  <head>
+    <style>
+      body { font-family: sans-serif; padding: 16px; }
+      summary { font-weight: bold; cursor: pointer; }
+      details { margin-bottom: 8px; }
+      .val { color: #333; }
+    </style>
+  </head>
+  <body>
+    <h1>NetCDF Structure Viewer</h1>
+    <details>
+      <summary style="font-size:1.2em;">${fileName}</summary>
+      ${dims}
+      ${coords}
+      ${dataVars}
+      ${globalAttrs}
+    </details>
+  </body>
+  </html>
+  `;
+}

--- a/src/views/datasetHtmlView.ts
+++ b/src/views/datasetHtmlView.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { NetCDFDataset, StoredNetCDF } from '../types';
 import { getSampleSlice } from '../utils/sampleSlice';
+import { escapeHtml } from '../utils/escapeHtml';
 
 /**
  * Opens a webview to display the entire dataset as an HTML table with collapsible sections.
@@ -17,30 +18,35 @@ export function showDatasetHtmlView(context: vscode.ExtensionContext, dataset: N
     'netcdfHtmlView',
     fileName, // Use the filename as the tab heading
     vscode.ViewColumn.One,
-    { enableScripts: true }
+    { enableScripts: false }
   );
 
-  panel.webview.html = getDatasetHtml(dataset, fileName);
+  panel.webview.html = getDatasetHtml(panel.webview, dataset, fileName);
 }
 
 /**
  * Returns HTML markup for the dataset using nested <details> elements, ordered and labeled.
  *
+ * @param webview - The webview instance for CSP source
  * @param dataset - The NetCDF dataset
  * @param fileName - Name of the file for display
  * @returns HTML string
  */
-export function getDatasetHtml(dataset: NetCDFDataset, fileName: string = 'NetCDF File'): string {
+export function getDatasetHtml(
+  webview: vscode.Webview,
+  dataset: NetCDFDataset,
+  fileName: string = 'NetCDF File'
+): string {
   const alwaysExpandable = new Set(['dtype', 'shape', 'dims', 'encoding']);
 
   function renderTree(node: unknown, label: string, indent = 0, parent?: Record<string, any>): string {
     // Special handling for sample_data
-    let displayLabel = label;
+    let displayLabel = escapeHtml(label);
     if (label === 'sample_data' && Array.isArray(node) && parent && (parent.shape || parent.dims)) {
       const shape: number[] =
         parent.shape || (parent.dims ? parent.dims.map((d: string) => parent[d]?.length || 0) : []);
       const sampleSlice = getSampleSlice(shape, node.length);
-      displayLabel = `sample_data ${sampleSlice}`;
+      displayLabel = `sample_data ${escapeHtml(sampleSlice)}`;
     }
 
     // Always expandable for certain keys, even if primitive
@@ -51,7 +57,7 @@ export function getDatasetHtml(dataset: NetCDFDataset, fileName: string = 'NetCD
           .map(([k, v]) => renderTree(v, k, indent + 1, node))
           .join('');
       } else {
-        content = `<div style="padding-left:${(indent + 1) * 20}px"><span class="val">${node}</span></div>`;
+        content = `<div style="padding-left:${(indent + 1) * 20}px"><span class="val">${escapeHtml(node)}</span></div>`;
       }
       return `<details>
         <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
@@ -74,7 +80,10 @@ export function getDatasetHtml(dataset: NetCDFDataset, fileName: string = 'NetCD
     if (Array.isArray(node)) {
       const preview = node
         .slice(0, 10)
-        .map((v, i) => `<div style="padding-left:${(indent + 1) * 20}px">[${i}]: <span class="val">${v}</span></div>`)
+        .map(
+          (v, i) =>
+            `<div style="padding-left:${(indent + 1) * 20}px">[${i}]: <span class="val">${escapeHtml(v)}</span></div>`
+        )
         .join('');
       return `<details>
       <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
@@ -83,7 +92,7 @@ export function getDatasetHtml(dataset: NetCDFDataset, fileName: string = 'NetCD
     }
 
     // For primitives, just show as a line
-    return `<div style="padding-left:${indent * 20}px">${displayLabel}: <span class="val">${node}</span></div>`;
+    return `<div style="padding-left:${indent * 20}px">${displayLabel}: <span class="val">${escapeHtml(node)}</span></div>`;
   }
 
   // Prepare ordered branches
@@ -96,6 +105,8 @@ export function getDatasetHtml(dataset: NetCDFDataset, fileName: string = 'NetCD
   <!DOCTYPE html>
   <html>
   <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource};">
     <style>
       body { font-family: sans-serif; padding: 16px; }
       summary { font-weight: bold; cursor: pointer; }
@@ -106,7 +117,7 @@ export function getDatasetHtml(dataset: NetCDFDataset, fileName: string = 'NetCD
   <body>
     <h1>NetCDF Structure Viewer</h1>
     <details>
-      <summary style="font-size:1.2em;">${fileName}</summary>
+      <summary style="font-size:1.2em;">${escapeHtml(fileName)}</summary>
       ${dims}
       ${coords}
       ${dataVars}

--- a/src/views/variableWebview.ts
+++ b/src/views/variableWebview.ts
@@ -1,9 +1,21 @@
 import * as vscode from 'vscode';
 import { NamedVariable } from '../types';
 import { getSampleSlice } from '../utils/sampleSlice';
+import { escapeHtml } from '../utils/escapeHtml';
+
+/**
+ * Escapes a string for safe use in JavaScript string literals.
+ */
+function escapeJs(unsafe: unknown): string {
+  const str = String(unsafe ?? '');
+  return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
 
 /**
  * Opens a Webview panel to preview the selected NetCDF variable.
+ *
+ * NOTE: This function is currently not wired up to any command.
+ * It can be used in the future to preview variables when clicked in the tree view.
  *
  * @param context - VS Code extension context
  * @param variable - The variable to preview
@@ -44,14 +56,8 @@ export function getWebviewContent(
   // URI for local Chart.js script in media folder
   const chartJsUri = webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'media', 'chart.js'));
 
-  // Format variable summary like xarray
-  const dimsStr =
-    variable.dims && variable.dims.length > 0
-      ? `(${variable.dims.map((d: string, i: number) => `${d}: ${variable.shape ? variable.shape[i] : '?'}`).join(', ')})`
-      : '';
-
   const attrsStr = Object.entries(variable.attrs || {})
-    .map(([k, v]) => `<tr><td>${k}</td><td>${JSON.stringify(v)}</td></tr>`)
+    .map(([k, v]) => `<tr><td>${escapeHtml(k)}</td><td>${escapeHtml(JSON.stringify(v))}</td></tr>`)
     .join('');
 
   // Read all data and take the first 10 values as sample
@@ -60,6 +66,14 @@ export function getWebviewContent(
 
   const shape = variable.shape || [];
   const sampleSlice = getSampleSlice(shape, sampleData.length);
+
+  const variableName = escapeHtml(variable.name || variable.label || '?');
+  const variableNameJs = escapeJs(variable.name || variable.label || '?');
+
+  const dimensionsDisplay =
+    variable.dims && variable.shape
+      ? variable.dims.map((d: string, i: number) => `${escapeHtml(d)} (${variable.shape[i]})`).join(' × ')
+      : (variable.dims || []).map((d) => escapeHtml(d)).join(' × ');
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -75,13 +89,9 @@ export function getWebviewContent(
     <title>Variable Preview</title>
 </head>
 <body>
-    <h1>${variable.name || variable.label || '?'}</h1>
-    <p><strong>Dimensions:</strong> ${
-      variable.dims && variable.shape
-        ? variable.dims.map((d: string, i: number) => `${d} (${variable.shape[i]})`).join(' × ')
-        : (variable.dims || []).join(' × ')
-    }</p>
-    <p><strong>Type:</strong> ${variable.dtype || '?'}</p>
+    <h1>${variableName}</h1>
+    <p><strong>Dimensions:</strong> ${dimensionsDisplay}</p>
+    <p><strong>Type:</strong> ${escapeHtml(variable.dtype || '?')}</p>
 
     <h2>Attributes</h2>
     <table>
@@ -90,14 +100,14 @@ export function getWebviewContent(
     </table>
 
     <h2>
-      Sample Data${sampleSlice ? ` ${sampleSlice}` : ''} (first ${sampleData.length} values)
+      Sample Data${sampleSlice ? ` ${escapeHtml(sampleSlice)}` : ''} (first ${sampleData.length} values)
     </h2>
 ${
   sampleData.length > 0
     ? `
       <table>
         <tr><th>Index</th><th>Value</th></tr>
-        ${sampleData.map((v, i) => `<tr><td>${i}</td><td>${v}</td></tr>`).join('')}
+        ${sampleData.map((v, i) => `<tr><td>${i}</td><td>${escapeHtml(v)}</td></tr>`).join('')}
       </table>
       <canvas id="chart" width="400" height="200"></canvas>
       `
@@ -120,7 +130,7 @@ ${
             data: {
                 labels: ${JSON.stringify(sampleData.map((_, i) => i))},
                 datasets: [{
-                    label: '${variable.name || variable.label || '?'}',
+                    label: '${variableNameJs}',
                     data: ${JSON.stringify(sampleData)},
                     fill: false,
                     tension: 0.1

--- a/src/views/variableWebview.ts
+++ b/src/views/variableWebview.ts
@@ -1,0 +1,141 @@
+import * as vscode from 'vscode';
+import { NamedVariable } from '../types';
+import { getSampleSlice } from '../utils/sampleSlice';
+
+/**
+ * Opens a Webview panel to preview the selected NetCDF variable.
+ *
+ * @param context - VS Code extension context
+ * @param variable - The variable to preview
+ */
+export function showVariableWebview(context: vscode.ExtensionContext, variable: NamedVariable): void {
+  const panel = vscode.window.createWebviewPanel(
+    'netcdfVarPreview',
+    `Preview: ${variable.name || variable.label || '?'}`,
+    vscode.ViewColumn.One,
+    {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'media')],
+    }
+  );
+
+  panel.webview.html = getWebviewContent(panel.webview, context, variable);
+
+  panel.webview.onDidReceiveMessage((msg) => {
+    if (msg.command === 'alert') {
+      vscode.window.showInformationMessage(msg.text);
+    }
+  });
+}
+
+/**
+ * Generates HTML for the Webview, including metadata and a mini-chart.
+ *
+ * @param webview - The webview instance
+ * @param context - VS Code extension context
+ * @param variable - The variable to display
+ * @returns HTML string
+ */
+export function getWebviewContent(
+  webview: vscode.Webview,
+  context: vscode.ExtensionContext,
+  variable: NamedVariable
+): string {
+  // URI for local Chart.js script in media folder
+  const chartJsUri = webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, 'media', 'chart.js'));
+
+  // Format variable summary like xarray
+  const dimsStr =
+    variable.dims && variable.dims.length > 0
+      ? `(${variable.dims.map((d: string, i: number) => `${d}: ${variable.shape ? variable.shape[i] : '?'}`).join(', ')})`
+      : '';
+
+  const attrsStr = Object.entries(variable.attrs || {})
+    .map(([k, v]) => `<tr><td>${k}</td><td>${JSON.stringify(v)}</td></tr>`)
+    .join('');
+
+  // Read all data and take the first 10 values as sample
+  const rawData: (number | string | null)[] = Array.isArray(variable.sample_data) ? variable.sample_data : [];
+  const sampleData = rawData.slice(0, 10);
+
+  const shape = variable.shape || [];
+  const sampleSlice = getSampleSlice(shape, sampleData.length);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; img-src ${webview.cspSource} https:; script-src 'nonce-chart' ${webview.cspSource}; style-src ${webview.cspSource};">
+    <style>
+        body { font-family: sans-serif; padding: 16px; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 16px; }
+        th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; }
+    </style>
+    <title>Variable Preview</title>
+</head>
+<body>
+    <h1>${variable.name || variable.label || '?'}</h1>
+    <p><strong>Dimensions:</strong> ${
+      variable.dims && variable.shape
+        ? variable.dims.map((d: string, i: number) => `${d} (${variable.shape[i]})`).join(' × ')
+        : (variable.dims || []).join(' × ')
+    }</p>
+    <p><strong>Type:</strong> ${variable.dtype || '?'}</p>
+
+    <h2>Attributes</h2>
+    <table>
+        <tr><th>Key</th><th>Value</th></tr>
+        ${attrsStr || '<tr><td colspan="2"><em>No attributes</em></td></tr>'}
+    </table>
+
+    <h2>
+      Sample Data${sampleSlice ? ` ${sampleSlice}` : ''} (first ${sampleData.length} values)
+    </h2>
+${
+  sampleData.length > 0
+    ? `
+      <table>
+        <tr><th>Index</th><th>Value</th></tr>
+        ${sampleData.map((v, i) => `<tr><td>${i}</td><td>${v}</td></tr>`).join('')}
+      </table>
+      <canvas id="chart" width="400" height="200"></canvas>
+      `
+    : '<p><em>No data available for this variable.</em></p>'
+}
+    ${
+      sampleData.length > 0
+        ? `
+    <!-- Acquire VS Code API -->
+    <script nonce="nonce-chart">
+        const vscode = acquireVsCodeApi();
+    </script>
+    <!-- Chart.js library -->
+    <script nonce="nonce-chart" src="${chartJsUri}"></script>
+    <!-- Render the chart -->
+    <script nonce="nonce-chart">
+        const ctx = document.getElementById('chart').getContext('2d');
+        new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: ${JSON.stringify(sampleData.map((_, i) => i))},
+                datasets: [{
+                    label: '${variable.name || variable.label || '?'}',
+                    data: ${JSON.stringify(sampleData)},
+                    fill: false,
+                    tension: 0.1
+                }]
+            },
+            options: { responsive: true }
+        });
+
+        ctx.canvas.addEventListener('click', () => {
+            vscode.postMessage({ command: 'alert', text: 'Chart clicked!' });
+        });
+    </script>
+    `
+        : ''
+    }
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary

- Add TypeScript interfaces to replace `any` types throughout the codebase
- Split monolithic `extension.ts` (544 lines) into focused modules (~98 lines entry point)
- Extract duplicate `getSampleSlice()` function into shared utility
- Update CONTRIBUTING.md with new project structure and TypeScript guidelines

## Changes

### New Files
| File | Purpose |
|------|---------|
| `src/types.ts` | TypeScript interfaces (`NetCDFDataset`, `NetCDFVariable`, etc.) |
| `src/providers/NetCDFTreeProvider.ts` | Tree view data provider |
| `src/views/datasetHtmlView.ts` | HTML dataset structure view |
| `src/views/variableWebview.ts` | Chart.js variable preview |
| `src/python/inspector.ts` | Python script execution |
| `src/utils/sampleSlice.ts` | Shared utility function |

### Benefits
- Compile-time type checking catches bugs earlier
- Better IDE autocompletion and documentation
- Single responsibility per module
- Easier to test and maintain

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] Webpack build succeeds
- [ ] Manual test: Open a NetCDF file and verify tree view works
- [ ] Manual test: Verify HTML view renders correctly

🤖 Generated with [Claude Code](https://claude.ai/code)