### PR TITLE
UX improvements: progress indicator, configurable sample size, context menu fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Thumbs.db
 # Editor
 *.swp
 *.swo
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,7 @@ src/
 - `inspect_netcdf.py` - Python script for reading NetCDF files
 - `package.json` - Extension manifest and contribution points
 - `webpack.config.js` - Build configuration
+
+## Planned Features
+
+- **CF Compliance Checker** - See `docs/cf-compliance-checker.md` and issue #14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# NetCDF Viewer - VS Code Extension
+
+A VS Code extension for viewing NetCDF files and their metadata using Python (xarray/netCDF4).
+
+## Commands
+
+```bash
+npm run compile     # Build extension (webpack production)
+npm run watch       # Build in watch mode (development)
+npm run lint        # Run ESLint
+npm run tsc         # TypeScript type checking
+npm run pretest     # compile + lint + tsc
+npm run test        # Run tests
+```
+
+## Testing the Extension
+
+Press **F5** in VS Code to launch the Extension Development Host. The extension runs in that new window, not the original.
+
+## Architecture
+
+```
+src/
+├── extension.ts              # Entry point, command registration
+├── types.ts                  # TypeScript interfaces
+├── providers/
+│   └── NetCDFTreeProvider.ts # Tree view data provider
+├── views/
+│   ├── datasetHtmlView.ts    # HTML webview for dataset display
+│   └── variableWebview.ts    # Variable-specific webview
+├── python/
+│   └── inspector.ts          # Python script execution
+├── utils/
+│   ├── escapeHtml.ts         # HTML escaping utility
+│   └── sampleSlice.ts        # Sample slice notation utility
+└── test/
+    └── extension.test.ts     # Tests
+```
+
+## Code Style
+
+- TypeScript with ES modules
+- ESLint with `@typescript-eslint` rules
+- Prettier for formatting
+- Use curly braces for all control structures
+- Semicolons required
+- camelCase for imports
+
+## Key Patterns
+
+- **Webviews**: Use VS Code CSS variables (`--vscode-foreground`, etc.) for theme compatibility
+- **Python interaction**: Via `child_process.execFile` in `inspector.ts`
+- **Configuration**: Access via `vscode.workspace.getConfiguration('netcdfViewer')`
+- **Tree views**: Implement `vscode.TreeDataProvider` interface
+
+## Git Workflow
+
+- Main branch: `main`
+- Feature branches: `feature/<description>`
+- Commits should be atomic and well-described
+- Use conventional commit style when appropriate
+
+## Related Files
+
+- `inspect_netcdf.py` - Python script for reading NetCDF files
+- `package.json` - Extension manifest and contribution points
+- `webpack.config.js` - Build configuration

--- a/README.md
+++ b/README.md
@@ -93,20 +93,20 @@ This extension uses Python (via [xarray](https://xarray.dev/) and [netCDF4](http
 **Requirements:**
 
 - Python 3.8 or higher
-- `xarray`, `netCDF4`, and `numpy` packages
+- `xarray` and `netCDF4` packages
 
 ### Installation Options
 
 **Using pip:**
 
 ```sh
-pip install xarray netCDF4 numpy
+pip install xarray netCDF4
 ```
 
 **Using conda:**
 
 ```sh
-conda install -c conda-forge xarray netCDF4 numpy
+conda install -c conda-forge xarray netCDF4
 ```
 
 **Using the provided environment file:**
@@ -129,6 +129,13 @@ Or manually in `settings.json`:
 ```json
 "netcdfViewer.pythonPath": "/path/to/python"
 ```
+
+### Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `netcdfViewer.pythonPath` | `python` | Path to Python executable |
+| `netcdfViewer.sampleSize` | `10` | Number of sample values to display per variable (1-1000) |
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -90,20 +90,53 @@
 
 This extension uses Python (via [xarray](https://xarray.dev/) and [netCDF4](https://unidata.github.io/netcdf4-python/)) to parse NetCDF files.
 
-**You must have:**
+**Requirements:**
 
-- Python 3.7+
-- `xarray` and `netCDF4` installed in your Python environment
+- Python 3.8 or higher
+- `xarray`, `netCDF4`, and `numpy` packages
 
-If you use a custom Python path, set it in your VS Code settings:
+### Installation Options
 
-- Select **File > Preferences > Settings** (or `Ctrl+,`)
-- Search for `netcdfViewer.pythonPath`
-- Set the path to your Python executable:
+**Using pip:**
 
-```markdown
+```sh
+pip install xarray netCDF4 numpy
+```
+
+**Using conda:**
+
+```sh
+conda install -c conda-forge xarray netCDF4 numpy
+```
+
+**Using the provided environment file:**
+
+```sh
+conda env create -f environment.yml
+conda activate netcdf-viewer
+```
+
+### Configuration
+
+If VS Code doesn't find Python automatically, set the path in your settings:
+
+1. Open Command Palette (`Ctrl+Shift+P`)
+2. Run "Select Python Environment for NetCDF Viewer"
+3. Choose your Python executable
+
+Or manually in `settings.json`:
+
+```json
 "netcdfViewer.pythonPath": "/path/to/python"
 ```
+
+### Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Python, xarray, or netCDF4 not found" | Ensure packages are installed and `pythonPath` is set correctly |
+| Extension doesn't detect Python | Use the "Select Python Environment" command |
+| Large files are slow | This is normal; consider using a subset of your data |
 
 ---
 

--- a/docs/cf-compliance-checker.md
+++ b/docs/cf-compliance-checker.md
@@ -1,0 +1,369 @@
+# CF Compliance Checker - Implementation Guide
+
+> **Issue**: #14
+> **Status**: Planned
+
+## Overview
+
+This document outlines the implementation plan for adding CF (Climate and Forecast) Conventions compliance checking to the NetCDF Viewer extension.
+
+## Background
+
+### What are CF Conventions?
+
+The [CF Conventions](https://cfconventions.org/) are metadata standards for Earth science data in NetCDF files:
+
+- **Standard Names**: Controlled vocabulary for physical quantities (e.g., `air_temperature`, `sea_surface_height`)
+- **Units**: Must be UDUNITS-compatible and match canonical units for standard names
+- **Coordinates**: Latitude, longitude, vertical, time with specific requirements
+- **Attributes**: Required and recommended global/variable attributes
+
+### Compliance Categories
+
+| Category | Severity | When Flagged |
+|----------|----------|--------------|
+| **Required** | HIGH (Error) | Violations of MUST/SHALL requirements |
+| **Recommended** | MEDIUM (Warning) | Violations of SHOULD requirements |
+| **Optional** | LOW (Info) | Suggestions for better practices |
+
+## Recommended Library
+
+### IOOS Compliance Checker
+
+```bash
+pip install compliance-checker
+# or
+conda install -c conda-forge compliance-checker
+```
+
+**Why this library?**
+- Active development and maintenance
+- Clean Python API with JSON output
+- Scoring system (points scored / points possible)
+- Priority levels map well to VS Code diagnostics
+- Supports CF versions 1.6 through latest
+
+### Alternative: CEDA CF-Checker
+
+```bash
+pip install cfchecker
+```
+
+Less recommended due to older API, but still functional.
+
+## Implementation Plan
+
+### File Structure
+
+```
+src/
+├── python/
+│   └── cfChecker.ts           # Python script executor
+├── providers/
+│   └── CFComplianceProvider.ts # Optional: tree view provider
+└── views/
+    └── complianceReportView.ts # HTML report webview
+
+check_cf_compliance.py          # Python script (root level)
+```
+
+### Phase 1: Python Script
+
+Create `check_cf_compliance.py`:
+
+```python
+#!/usr/bin/env python3
+"""CF Compliance checker for NetCDF Viewer extension."""
+
+import sys
+import json
+from compliance_checker.runner import ComplianceChecker, CheckSuite
+
+def check_compliance(filepath: str, cf_version: str = "latest") -> dict:
+    """
+    Run CF compliance check and return structured results.
+
+    Args:
+        filepath: Path to NetCDF file
+        cf_version: CF version to check against (e.g., "1.8", "latest")
+
+    Returns:
+        Dictionary with score, summary, and issues
+    """
+    check_suite = CheckSuite()
+    check_suite.load_all_available_checkers()
+
+    # Determine checker name
+    checker_name = "cf" if cf_version == "latest" else f"cf:{cf_version}"
+
+    # Run check with JSON output to capture results
+    import tempfile
+    import os
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        temp_path = f.name
+
+    try:
+        return_value, errors = ComplianceChecker.run_checker(
+            path=filepath,
+            checker_names=[checker_name],
+            verbose=0,
+            criteria='normal',
+            output_filename=temp_path,
+            output_format='json_new'
+        )
+
+        with open(temp_path, 'r') as f:
+            raw_results = json.load(f)
+
+        return transform_results(raw_results, checker_name)
+    finally:
+        os.unlink(temp_path)
+
+
+def transform_results(raw: dict, checker_name: str) -> dict:
+    """Transform compliance-checker output to extension-friendly format."""
+
+    # Extract the CF results (key varies by version)
+    cf_key = None
+    for key in raw.keys():
+        if key.startswith('cf'):
+            cf_key = key
+            break
+
+    if not cf_key or cf_key not in raw:
+        return {"error": "No CF results found"}
+
+    cf_data = raw[cf_key]
+
+    # Build summary
+    high_passed = cf_data.get('high_count', 0)
+    medium_passed = cf_data.get('medium_count', 0)
+    low_passed = cf_data.get('low_count', 0)
+
+    scored = cf_data.get('scored_points', 0)
+    possible = cf_data.get('possible_points', 0)
+    percentage = (scored / possible * 100) if possible > 0 else 0
+
+    # Extract issues from all_priorities
+    issues = []
+    high_failed = 0
+    medium_failed = 0
+    low_failed = 0
+
+    for check in cf_data.get('all_priorities', []):
+        value = check.get('value', [0, 0])
+        if isinstance(value, list) and len(value) == 2:
+            passed, total = value
+            if passed < total:  # Has failures
+                weight = check.get('weight', 2)
+                severity = 'high' if weight >= 3 else ('medium' if weight >= 2 else 'low')
+
+                if severity == 'high':
+                    high_failed += (total - passed)
+                elif severity == 'medium':
+                    medium_failed += (total - passed)
+                else:
+                    low_failed += (total - passed)
+
+                for msg in check.get('msgs', []):
+                    issues.append({
+                        'severity': severity,
+                        'category': categorize_check(check.get('name', '')),
+                        'variable': extract_variable(msg),
+                        'message': msg,
+                        'checkName': check.get('name', '')
+                    })
+
+    return {
+        'cfVersion': checker_name.replace('cf:', '').replace('cf', 'latest'),
+        'score': {
+            'scored': scored,
+            'possible': possible,
+            'percentage': round(percentage, 1)
+        },
+        'summary': {
+            'high': {'passed': high_passed, 'failed': high_failed},
+            'medium': {'passed': medium_passed, 'failed': medium_failed},
+            'low': {'passed': low_passed, 'failed': low_failed}
+        },
+        'issues': issues
+    }
+
+
+def categorize_check(name: str) -> str:
+    """Categorize a check by its name."""
+    name_lower = name.lower()
+    if 'unit' in name_lower:
+        return 'units'
+    elif 'coord' in name_lower or 'lat' in name_lower or 'lon' in name_lower:
+        return 'coordinates'
+    elif 'attr' in name_lower or 'convention' in name_lower:
+        return 'attributes'
+    elif 'name' in name_lower:
+        return 'naming'
+    elif 'time' in name_lower:
+        return 'time'
+    elif 'grid' in name_lower or 'crs' in name_lower:
+        return 'grid_mapping'
+    else:
+        return 'general'
+
+
+def extract_variable(msg: str) -> str | None:
+    """Try to extract variable name from message."""
+    # Common patterns: "Variable 'foo'", "variable foo", etc.
+    import re
+    match = re.search(r"[Vv]ariable ['\"]?(\w+)['\"]?", msg)
+    if match:
+        return match.group(1)
+    return None
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(json.dumps({'error': 'No file provided'}))
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    cf_version = sys.argv[2] if len(sys.argv) > 2 else 'latest'
+
+    try:
+        result = check_compliance(filepath, cf_version)
+        print(json.dumps(result))
+    except Exception as e:
+        print(json.dumps({'error': str(e)}))
+        sys.exit(1)
+```
+
+### Phase 2: TypeScript Integration
+
+Create `src/python/cfChecker.ts`:
+
+```typescript
+import { execFile } from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export interface CFComplianceResult {
+  cfVersion: string;
+  score: {
+    scored: number;
+    possible: number;
+    percentage: number;
+  };
+  summary: {
+    high: { passed: number; failed: number };
+    medium: { passed: number; failed: number };
+    low: { passed: number; failed: number };
+  };
+  issues: CFIssue[];
+  error?: string;
+}
+
+export interface CFIssue {
+  severity: 'high' | 'medium' | 'low';
+  category: string;
+  variable?: string;
+  message: string;
+  checkName?: string;
+}
+
+export async function checkCFCompliance(
+  context: vscode.ExtensionContext,
+  filePath: string,
+  cfVersion: string = 'latest'
+): Promise<CFComplianceResult> {
+  const scriptPath = path.join(context.extensionPath, 'check_cf_compliance.py');
+  const config = vscode.workspace.getConfiguration('netcdfViewer');
+  const pythonPath = config.get<string>('pythonPath', 'python');
+
+  return new Promise((resolve, reject) => {
+    execFile(
+      pythonPath,
+      [scriptPath, filePath, cfVersion],
+      { maxBuffer: 10 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(`Python error: ${stderr || err.message}`);
+        } else {
+          try {
+            resolve(JSON.parse(stdout));
+          } catch (e) {
+            reject(`Failed to parse output: ${stdout.slice(0, 500)}`);
+          }
+        }
+      }
+    );
+  });
+}
+```
+
+### Phase 3: Webview Report
+
+Create `src/views/complianceReportView.ts` following the pattern in `datasetHtmlView.ts`:
+
+- Use VS Code CSS variables for theme support
+- Show score prominently at top
+- Group issues by severity with expandable sections
+- Color-code: red (high), yellow (medium), blue (low)
+
+### Phase 4: Command Registration
+
+In `extension.ts`:
+
+```typescript
+context.subscriptions.push(
+  vscode.commands.registerCommand('netcdf-viewer.checkCFCompliance', async () => {
+    const stored = context.workspaceState.get<StoredNetCDF>('lastNetCDF');
+    if (!stored?.uri) {
+      vscode.window.showWarningMessage('No NetCDF file loaded');
+      return;
+    }
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Checking CF Compliance...',
+        cancellable: false
+      },
+      async () => {
+        const result = await checkCFCompliance(context, stored.uri.fsPath);
+        showComplianceReport(context, result, stored.uri);
+      }
+    );
+  })
+);
+```
+
+## Configuration Options
+
+Add to `package.json`:
+
+```json
+{
+  "netcdfViewer.cfVersion": {
+    "type": "string",
+    "default": "latest",
+    "enum": ["latest", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11"],
+    "description": "CF Conventions version to check against"
+  }
+}
+```
+
+## References
+
+### Official Documentation
+- [CF Conventions](https://cfconventions.org/)
+- [CF Conventions Specification](https://cfconventions.org/cf-conventions/cf-conventions.html)
+- [CF Conformance Requirements](https://cfconventions.org/Data/cf-documents/requirements-recommendations/conformance-1.9.html)
+- [CF Standard Names Table](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html)
+
+### Libraries
+- [IOOS Compliance Checker](https://github.com/ioos/compliance-checker) - Recommended
+- [IOOS Compliance Checker Docs](https://ioos.github.io/compliance-checker/)
+- [CEDA CF-Checker](https://github.com/cedadev/cf-checker) - Alternative
+
+### Related Standards
+- [UDUNITS](https://www.unidata.ucar.edu/software/udunits/) - Units validation
+- [COARDS](https://ferret.pmel.noaa.gov/Ferret/documentation/coards-netcdf-conventions) - Predecessor to CF

--- a/inspect_netcdf.py
+++ b/inspect_netcdf.py
@@ -25,6 +25,14 @@ if len(sys.argv) < 2:
     print(json.dumps({"error": "No file provided"}))
     sys.exit(1)
 
+# Get sample size from second argument, default to 10
+sample_size = 10
+if len(sys.argv) >= 3:
+    try:
+        sample_size = max(1, min(1000, int(sys.argv[2])))
+    except ValueError:
+        pass  # Use default if invalid
+
 try:
     ds = xr.open_dataset(sys.argv[1])
     d = ds.to_dict(data=False)  # Only metadata
@@ -33,7 +41,7 @@ try:
     for varname, var in ds.data_vars.items():
         try:
             arr = var.values
-            sample = arr.flat[:10] if arr.size > 10 else arr.flat[:]
+            sample = arr.flat[:sample_size] if arr.size > sample_size else arr.flat[:]
             d['data_vars'][varname]['sample_data'] = [convert(x) for x in sample]
         except Exception as e:
             d['data_vars'][varname]['sample_data'] = [str(e)]
@@ -47,7 +55,7 @@ try:
     for coordname, coord in ds.coords.items():
         try:
             arr = coord.values
-            sample = arr.flat[:10] if arr.size > 10 else arr.flat[:]
+            sample = arr.flat[:sample_size] if arr.size > sample_size else arr.flat[:]
             d['coords'][coordname]['sample_data'] = [convert(x) for x in sample]
         except Exception as e:
             d['coords'][coordname]['sample_data'] = [str(e)]

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "activationEvents": [
     "onCommand:netcdf-viewer.openFile",
     "onCommand:netcdf-viewer.selectPythonEnv",
-    "onCommand:netcdf-viewer.showHtmlView",
-    "onCommand:netcdf-viewer.setSampleSize"
+    "onCommand:netcdf-viewer.showHtmlView"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "activationEvents": [
     "onCommand:netcdf-viewer.openFile",
     "onCommand:netcdf-viewer.selectPythonEnv",
-    "onCommand:netcdf-viewer.showHtmlView"
+    "onCommand:netcdf-viewer.showHtmlView",
+    "onCommand:netcdf-viewer.setSampleSize"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -55,14 +55,14 @@
       "explorer/context": [
         {
           "command": "netcdf-viewer.openFile",
-          "when": "resourceExtname == .nc",
+          "when": "resourceExtname =~ /^\\.(nc|nc4|cdf|h5)$/",
           "group": "navigation"
         }
       ],
       "editor/title": [
         {
           "command": "netcdf-viewer.openFile",
-          "when": "resourceExtname == .nc",
+          "when": "resourceExtname =~ /^\\.(nc|nc4|cdf|h5)$/",
           "group": "navigation"
         }
       ]
@@ -75,6 +75,13 @@
           "type": "string",
           "default": "python",
           "description": "Path to the Python interpreter with xarray and netCDF4 installed."
+        },
+        "netcdfViewer.sampleSize": {
+          "type": "number",
+          "default": 10,
+          "minimum": 1,
+          "maximum": 1000,
+          "description": "Number of sample values to display for each variable (1-1000)."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,17 @@ export function activate(context: vscode.ExtensionContext): void {
     }
 
     try {
-      const result = await inspectNetCDFWithPython(context, fileUri.fsPath);
+      const result = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Loading NetCDF file...',
+          cancellable: false,
+        },
+        async () => {
+          return inspectNetCDFWithPython(context, fileUri.fsPath);
+        }
+      );
+
       if (isInspectError(result)) {
         vscode.window.showErrorMessage('Python error: ' + result.error);
         return;

--- a/src/providers/NetCDFTreeProvider.ts
+++ b/src/providers/NetCDFTreeProvider.ts
@@ -106,10 +106,10 @@ export class NetCDFTreeProvider implements vscode.TreeDataProvider<NetCDFTreeIte
       );
     }
 
-    // Show sample data children
+    // Show sample data children (sample size is configured via netcdfViewer.sampleSize)
     if (element.contextValue === 'sample' && element.data) {
       const varData = element.data as NamedVariable;
-      const sampleData = Array.isArray(varData.sample_data) ? varData.sample_data.slice(0, 10) : [];
+      const sampleData = Array.isArray(varData.sample_data) ? varData.sample_data : [];
       return sampleData.map((v, i) => new NetCDFTreeItem(`[${i}]: ${v}`, vscode.TreeItemCollapsibleState.None));
     }
 

--- a/src/python/inspector.ts
+++ b/src/python/inspector.ts
@@ -15,32 +15,39 @@ export async function inspectNetCDFWithPython(
   filePath: string
 ): Promise<InspectResult> {
   const scriptPath = path.join(context.extensionPath, 'inspect_netcdf.py');
-  const pythonPath = vscode.workspace.getConfiguration().get<string>('netcdfViewer.pythonPath', 'python');
+  const config = vscode.workspace.getConfiguration('netcdfViewer');
+  const pythonPath = config.get<string>('pythonPath', 'python');
+  const sampleSize = config.get<number>('sampleSize', 10);
 
   const MAX_ERROR_LENGTH = 500;
 
   return new Promise((resolve, reject) => {
-    execFile(pythonPath, [scriptPath, filePath], { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
-      if (err) {
-        // Truncate error output to avoid overwhelming the user
-        let details = stderr || err.message || 'Unknown error';
-        if (details.length > MAX_ERROR_LENGTH) {
-          details = details.slice(0, MAX_ERROR_LENGTH) + '... [truncated]';
-        }
-        reject(`Python error: ${details}`);
-      } else {
-        try {
-          resolve(JSON.parse(stdout));
-        } catch (e) {
-          // Truncate output snippet for parse errors
-          let snippet = stdout || '';
-          if (snippet.length > MAX_ERROR_LENGTH) {
-            snippet = snippet.slice(0, MAX_ERROR_LENGTH) + '... [truncated]';
+    execFile(
+      pythonPath,
+      [scriptPath, filePath, String(sampleSize)],
+      { maxBuffer: 10 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          // Truncate error output to avoid overwhelming the user
+          let details = stderr || err.message || 'Unknown error';
+          if (details.length > MAX_ERROR_LENGTH) {
+            details = details.slice(0, MAX_ERROR_LENGTH) + '... [truncated]';
           }
-          reject(`Failed to parse Python output: ${snippet}`);
+          reject(`Python error: ${details}`);
+        } else {
+          try {
+            resolve(JSON.parse(stdout));
+          } catch (e) {
+            // Truncate output snippet for parse errors
+            let snippet = stdout || '';
+            if (snippet.length > MAX_ERROR_LENGTH) {
+              snippet = snippet.slice(0, MAX_ERROR_LENGTH) + '... [truncated]';
+            }
+            reject(`Failed to parse Python output: ${snippet}`);
+          }
         }
       }
-    });
+    );
   });
 }
 

--- a/src/utils/escapeHtml.ts
+++ b/src/utils/escapeHtml.ts
@@ -11,8 +11,12 @@ export function escapeHtml(unsafe: unknown): string {
   } else if (unsafe === undefined) {
     str = 'undefined';
   } else if (typeof unsafe === 'object') {
-    // Handle arrays and objects by JSON-stringifying them
-    str = JSON.stringify(unsafe);
+    // Handle arrays and objects; JSON.stringify may throw on circular or non-serializable values
+    try {
+      str = JSON.stringify(unsafe);
+    } catch {
+      str = '[Object]';
+    }
   } else {
     str = String(unsafe);
   }

--- a/src/utils/escapeHtml.ts
+++ b/src/utils/escapeHtml.ts
@@ -5,7 +5,17 @@
  * @returns Escaped string safe for HTML insertion
  */
 export function escapeHtml(unsafe: unknown): string {
-  const str = String(unsafe ?? '');
+  let str: string;
+  if (unsafe === null) {
+    str = 'null';
+  } else if (unsafe === undefined) {
+    str = 'undefined';
+  } else if (typeof unsafe === 'object') {
+    // Handle arrays and objects by JSON-stringifying them
+    str = JSON.stringify(unsafe);
+  } else {
+    str = String(unsafe);
+  }
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/src/views/datasetHtmlView.ts
+++ b/src/views/datasetHtmlView.ts
@@ -16,12 +16,108 @@ export function showDatasetHtmlView(context: vscode.ExtensionContext, dataset: N
 
   const panel = vscode.window.createWebviewPanel(
     'netcdfHtmlView',
-    fileName, // Use the filename as the tab heading
+    fileName,
     vscode.ViewColumn.One,
     { enableScripts: false }
   );
 
   panel.webview.html = getDatasetHtml(panel.webview, dataset, fileName);
+}
+
+/** CSS styles using VS Code theme variables for proper light/dark theme support */
+const CSS_STYLES = `
+  :root {
+    --indent-size: 12px;
+  }
+  body {
+    font-family: var(--vscode-font-family, sans-serif);
+    font-size: var(--vscode-font-size, 13px);
+    color: var(--vscode-foreground);
+    background-color: var(--vscode-editor-background);
+    padding: 16px;
+    line-height: 1.5;
+  }
+  h1 {
+    color: var(--vscode-foreground);
+    font-size: 1.4em;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    padding-bottom: 8px;
+  }
+  details {
+    margin-bottom: 2px;
+  }
+  summary {
+    cursor: pointer;
+    padding: 2px 0;
+  }
+  summary:hover {
+    background-color: var(--vscode-list-hoverBackground);
+  }
+  .section-header {
+    font-weight: bold;
+    color: var(--vscode-textLink-foreground);
+  }
+  .file-header {
+    font-size: 1.1em;
+    font-weight: bold;
+  }
+  .var-name {
+    color: var(--vscode-symbolIcon-variableForeground, var(--vscode-foreground));
+    font-weight: 600;
+  }
+  .attr-name {
+    color: var(--vscode-symbolIcon-propertyForeground, #9cdcfe);
+  }
+  .key {
+    color: var(--vscode-foreground);
+  }
+  .val {
+    color: var(--vscode-debugTokenExpression-string, #ce9178);
+    font-family: var(--vscode-editor-font-family, monospace);
+  }
+  .val-number {
+    color: var(--vscode-debugTokenExpression-number, #b5cea8);
+    font-family: var(--vscode-editor-font-family, monospace);
+  }
+  .val-null {
+    color: var(--vscode-debugTokenExpression-name, #569cd6);
+    font-style: italic;
+  }
+  .index {
+    color: var(--vscode-descriptionForeground);
+    font-family: var(--vscode-editor-font-family, monospace);
+  }
+  /* Use margin-left on details/divs for tree indentation */
+  .indent-1 { margin-left: calc(1 * var(--indent-size)); }
+  .indent-2 { margin-left: calc(2 * var(--indent-size)); }
+  .indent-3 { margin-left: calc(3 * var(--indent-size)); }
+  .indent-4 { margin-left: calc(4 * var(--indent-size)); }
+  .indent-5 { margin-left: calc(5 * var(--indent-size)); }
+  .indent-6 { margin-left: calc(6 * var(--indent-size)); }
+  .row {
+    padding: 1px 0;
+  }
+`;
+
+/** Maximum indent level supported by CSS classes */
+const MAX_INDENT = 6;
+
+/**
+ * Returns the appropriate CSS class for a given indent level.
+ */
+function indentClass(level: number): string {
+  const clamped = Math.min(Math.max(level, 0), MAX_INDENT);
+  return clamped > 0 ? `indent-${clamped}` : '';
+}
+
+/**
+ * Returns the appropriate value class based on the value type.
+ */
+function valueClass(value: unknown): string {
+  if (value === null || value === undefined) {return 'val-null';}
+  if (typeof value === 'number') {return 'val-number';}
+  return 'val';
 }
 
 /**
@@ -38,15 +134,33 @@ export function getDatasetHtml(
   fileName: string = 'NetCDF File'
 ): string {
   const alwaysExpandable = new Set(['dtype', 'shape', 'dims', 'encoding']);
+  const sectionLabels = new Set(['Dimensions', 'Coordinates', 'Data Variables', 'Global Attributes']);
 
-  function renderTree(node: unknown, label: string, indent = 0, parent?: Record<string, any>): string {
-    // Special handling for sample_data
+  function renderTree(
+    node: unknown,
+    label: string,
+    indent = 0,
+    parent?: Record<string, unknown>,
+    parentKey?: string
+  ): string {
+    const indentCls = indentClass(indent);
+    const isSection = sectionLabels.has(label);
+    const isVariable = parentKey === 'data_vars' || parentKey === 'coords';
+
+    // Determine label styling
+    let labelClass = 'key';
+    if (isSection) {labelClass = 'section-header';}
+    else if (isVariable) {labelClass = 'var-name';}
+    else if (parentKey === 'attrs') {labelClass = 'attr-name';}
+
+    // Special handling for sample_data label
     let displayLabel = escapeHtml(label);
     if (label === 'sample_data' && Array.isArray(node) && parent && (parent.shape || parent.dims)) {
       const shape: number[] =
-        parent.shape || (parent.dims ? parent.dims.map((d: string) => parent[d]?.length || 0) : []);
+        (parent.shape as number[]) ||
+        ((parent.dims as string[])?.map((d: string) => (parent[d] as number[])?.length || 0) ?? []);
       const sampleSlice = getSampleSlice(shape, node.length);
-      displayLabel = `sample_data ${escapeHtml(sampleSlice)}`;
+      displayLabel = `sample_data <span class="val">${escapeHtml(sampleSlice)}</span>`;
     }
 
     // Always expandable for certain keys, even if primitive
@@ -54,74 +168,73 @@ export function getDatasetHtml(
       let content = '';
       if (typeof node === 'object' && node !== null) {
         content = Object.entries(node)
-          .map(([k, v]) => renderTree(v, k, indent + 1, node))
+          .map(([k, v]) => renderTree(v, k, indent + 1, node as Record<string, unknown>, label))
           .join('');
       } else {
-        content = `<div style="padding-left:${(indent + 1) * 20}px"><span class="val">${escapeHtml(node)}</span></div>`;
+        const valCls = valueClass(node);
+        content = `<div class="row"><span class="${valCls}">${escapeHtml(node)}</span></div>`;
       }
-      return `<details>
-        <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
+      return `<details class="${indentCls}">
+        <summary><span class="${labelClass}">${displayLabel}</span></summary>
         ${content}
       </details>`;
     }
 
     // For plain objects, render as expandable
     if (typeof node === 'object' && node !== null && !Array.isArray(node)) {
-      const children = Object.entries(node)
-        .map(([k, v]) => renderTree(v, k, indent + 1, node))
+      const nodeRecord = node as Record<string, unknown>;
+      const children = Object.entries(nodeRecord)
+        .map(([k, v]) => renderTree(v, k, indent + 1, nodeRecord, isVariable ? 'variable' : parentKey))
         .join('');
-      return `<details>
-      <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
-      ${children}
-    </details>`;
+      return `<details class="${indentCls}">
+        <summary><span class="${labelClass}">${displayLabel}</span></summary>
+        ${children}
+      </details>`;
     }
 
-    // For arrays, show a preview (sample size is configured via netcdfViewer.sampleSize)
+    // For arrays, show values
     if (Array.isArray(node)) {
-      const preview = node.map(
-          (v, i) =>
-            `<div style="padding-left:${(indent + 1) * 20}px">[${i}]: <span class="val">${escapeHtml(v)}</span></div>`
-        )
+      const preview = node
+        .map((v, i) => {
+          const valCls = valueClass(v);
+          return `<div class="row"><span class="index">[${i}]:</span> <span class="${valCls}">${escapeHtml(v)}</span></div>`;
+        })
         .join('');
-      return `<details>
-      <summary style="padding-left:${indent * 20}px">${displayLabel}</summary>
-      ${preview}
-    </details>`;
+      return `<details class="${indentCls}">
+        <summary><span class="${labelClass}">${displayLabel}</span></summary>
+        ${preview}
+      </details>`;
     }
 
-    // For primitives, just show as a line
-    return `<div style="padding-left:${indent * 20}px">${displayLabel}: <span class="val">${escapeHtml(node)}</span></div>`;
+    // For primitives, show as a line
+    const valCls = valueClass(node);
+    return `<div class="row ${indentCls}"><span class="${labelClass}">${displayLabel}:</span> <span class="${valCls}">${escapeHtml(node)}</span></div>`;
   }
 
   // Prepare ordered branches
-  const dims = dataset.dims ? renderTree(dataset.dims, 'Dimensions', 1) : '';
-  const coords = dataset.coords ? renderTree(dataset.coords, 'Coordinates', 1) : '';
-  const dataVars = dataset.data_vars ? renderTree(dataset.data_vars, 'Data Variables', 1) : '';
-  const globalAttrs = dataset.attrs ? renderTree(dataset.attrs, 'Global Attributes', 1) : '';
+  const dims = dataset.dims ? renderTree(dataset.dims, 'Dimensions', 1, undefined, 'dims') : '';
+  const coords = dataset.coords ? renderTree(dataset.coords, 'Coordinates', 1, undefined, 'coords') : '';
+  const dataVars = dataset.data_vars
+    ? renderTree(dataset.data_vars, 'Data Variables', 1, undefined, 'data_vars')
+    : '';
+  const globalAttrs = dataset.attrs ? renderTree(dataset.attrs, 'Global Attributes', 1, undefined, 'attrs') : '';
 
-  return `
-  <!DOCTYPE html>
-  <html>
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline';">
-    <style>
-      body { font-family: sans-serif; padding: 16px; }
-      summary { font-weight: bold; cursor: pointer; }
-      details { margin-bottom: 8px; }
-      .val { color: #333; }
-    </style>
-  </head>
-  <body>
-    <h1>NetCDF Structure Viewer</h1>
-    <details>
-      <summary style="font-size:1.2em;">${escapeHtml(fileName)}</summary>
-      ${dims}
-      ${coords}
-      ${dataVars}
-      ${globalAttrs}
-    </details>
-  </body>
-  </html>
-  `;
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline';">
+  <style>${CSS_STYLES}</style>
+</head>
+<body>
+  <h1>NetCDF Structure Viewer</h1>
+  <details open>
+    <summary class="file-header">${escapeHtml(fileName)}</summary>
+    ${dims}
+    ${coords}
+    ${dataVars}
+    ${globalAttrs}
+  </details>
+</body>
+</html>`;
 }

--- a/src/views/datasetHtmlView.ts
+++ b/src/views/datasetHtmlView.ts
@@ -104,7 +104,7 @@ export function getDatasetHtml(
   <html>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource};">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline';">
     <style>
       body { font-family: sans-serif; padding: 16px; }
       summary { font-weight: bold; cursor: pointer; }

--- a/src/views/datasetHtmlView.ts
+++ b/src/views/datasetHtmlView.ts
@@ -103,6 +103,9 @@ const CSS_STYLES = `
 /** Maximum indent level supported by CSS classes */
 const MAX_INDENT = 6;
 
+/** Maximum number of array elements to display (prevents UI overload) */
+const MAX_ARRAY_DISPLAY = 100;
+
 /**
  * Returns the appropriate CSS class for a given indent level.
  */
@@ -155,11 +158,8 @@ export function getDatasetHtml(
 
     // Special handling for sample_data label
     let displayLabel = escapeHtml(label);
-    if (label === 'sample_data' && Array.isArray(node) && parent && (parent.shape || parent.dims)) {
-      const shape: number[] =
-        (parent.shape as number[]) ||
-        ((parent.dims as string[])?.map((d: string) => (parent[d] as number[])?.length || 0) ?? []);
-      const sampleSlice = getSampleSlice(shape, node.length);
+    if (label === 'sample_data' && Array.isArray(node) && parent?.shape) {
+      const sampleSlice = getSampleSlice(parent.shape as number[], node.length);
       displayLabel = `sample_data <span class="val">${escapeHtml(sampleSlice)}</span>`;
     }
 
@@ -192,17 +192,22 @@ export function getDatasetHtml(
       </details>`;
     }
 
-    // For arrays, show values
+    // For arrays, show values (limited to prevent UI overload)
     if (Array.isArray(node)) {
-      const preview = node
+      const limitedNode = node.slice(0, MAX_ARRAY_DISPLAY);
+      const truncated = node.length > MAX_ARRAY_DISPLAY;
+      const preview = limitedNode
         .map((v, i) => {
           const valCls = valueClass(v);
           return `<div class="row"><span class="index">[${i}]:</span> <span class="${valCls}">${escapeHtml(v)}</span></div>`;
         })
         .join('');
+      const truncatedNote = truncated
+        ? `<div class="row"><span class="val-null">... and ${node.length - MAX_ARRAY_DISPLAY} more items</span></div>`
+        : '';
       return `<details class="${indentCls}">
         <summary><span class="${labelClass}">${displayLabel}</span></summary>
-        ${preview}
+        ${preview}${truncatedNote}
       </details>`;
     }
 

--- a/src/views/datasetHtmlView.ts
+++ b/src/views/datasetHtmlView.ts
@@ -76,11 +76,9 @@ export function getDatasetHtml(
     </details>`;
     }
 
-    // For arrays, show a preview (first 10 values)
+    // For arrays, show a preview (sample size is configured via netcdfViewer.sampleSize)
     if (Array.isArray(node)) {
-      const preview = node
-        .slice(0, 10)
-        .map(
+      const preview = node.map(
           (v, i) =>
             `<div style="padding-left:${(indent + 1) * 20}px">[${i}]: <span class="val">${escapeHtml(v)}</span></div>`
         )

--- a/src/views/variableWebview.ts
+++ b/src/views/variableWebview.ts
@@ -60,9 +60,8 @@ export function getWebviewContent(
     .map(([k, v]) => `<tr><td>${escapeHtml(k)}</td><td>${escapeHtml(JSON.stringify(v))}</td></tr>`)
     .join('');
 
-  // Read all data and take the first 10 values as sample
-  const rawData: (number | string | null)[] = Array.isArray(variable.sample_data) ? variable.sample_data : [];
-  const sampleData = rawData.slice(0, 10);
+  // Sample data (sample size is configured via netcdfViewer.sampleSize)
+  const sampleData: (number | string | null)[] = Array.isArray(variable.sample_data) ? variable.sample_data : [];
 
   const shape = variable.shape || [];
   const sampleSlice = getSampleSlice(shape, sampleData.length);


### PR DESCRIPTION
## Summary

Follow-up improvements to enhance user experience and configuration options.

Closes #12

## Changes

### 1. Progress indicator for Python execution
- Shows notification while loading NetCDF files
- Prevents UI appearing frozen on large files

### 2. Configurable sample size
- New setting: `netcdfViewer.sampleSize` (1-1000, default: 10)
- Controls how many sample values are displayed for each variable
- Applied at Python level for efficiency

### 3. Context menu for all supported extensions
- **Before:** Only `.nc` files showed context menu
- **After:** `.nc`, `.nc4`, `.cdf`, `.h5` all show context menu

### 4. Improved Python documentation
- Added pip installation instructions
- Added conda installation instructions
- Added troubleshooting table

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] Webpack build succeeds
- [ ] Manual test: Open a large NetCDF file and verify progress indicator shows
- [ ] Manual test: Change `sampleSize` setting and verify different number of samples displayed
- [ ] Manual test: Right-click `.nc4` or `.h5` file and verify context menu appears

🤖 Generated with [Claude Code](https://claude.ai/code)